### PR TITLE
Make function/cursor keys work. Right now ignores keypad mode and alt…

### DIFF
--- a/Src/Console.cpp
+++ b/Src/Console.cpp
@@ -1,0 +1,24 @@
+/// \file Console.cpp
+///
+/// \date Feb 6, 2016
+///
+/// \author Douglas Miller
+///
+
+#include "Console.h"
+
+Console::Console(int argc, char **argv)
+{
+
+}
+
+Console::~Console()
+{
+
+}
+
+std::string Console::command(std::string cmd)
+{
+    // TODO: develop protocol of commands,
+    // e.g. "list all disk drives and media" and "mount new media".
+}

--- a/Src/Console.h
+++ b/Src/Console.h
@@ -1,0 +1,40 @@
+/// \file Console.h
+///
+/// \date Feb 6, 2016
+/// \author Douglas Miller
+///
+
+#ifndef CONSOLE_H_
+#define CONSOLE_H_
+
+#include "Terminal.h"
+#include <string>
+
+/// \class Console
+///
+/// \brief  interface Console.
+///
+/// Base class for generic terminal.
+///
+class Console : public Terminal
+{
+  public:
+    Console(int argc, char **argv);
+    virtual ~Console();
+
+    virtual void run() = 0;
+    virtual void init() = 0;
+    virtual void reset() = 0;
+    std::string command(std::string cmd);
+
+    // obsolete? deprecated?
+    virtual void processCharacter(char ch) = 0;
+    virtual void display() = 0;
+    virtual void keypress(char ch) = 0;
+    virtual bool checkUpdated() = 0;
+
+  private:
+
+};
+
+#endif // CONSOLE_H_

--- a/Src/H89.cpp
+++ b/Src/H89.cpp
@@ -9,7 +9,6 @@
 #include "ROM.h"
 #include "RAM.h"
 #include "z80.h"
-#include "h19.h"
 #include "AddressBus.h"
 #include "h89-timer.h"
 #include "h89-io.h"
@@ -27,6 +26,7 @@
 #include "HardSectoredDisk.h"
 #include "SoftSectoredDisk.h"
 #include "EightInchDisk.h"
+#include "Console.h"
 #include "logger.h"
 #include "propertyutil.h"
 
@@ -34,10 +34,16 @@
 
 H89::H89()
 {
+}
+
+void H89::buildSystem(Console *console)
+{
     PropertyUtil::PropertyMapT props;
     // TODO: allow specification of config file via cmdline args.
     std::string cfg;
     char *env = getenv("V89_CONFIG");
+
+    this->console = console;
 
     if (env)
     {
@@ -70,7 +76,6 @@ H89::H89()
     // Possibly set defaults and write/create file.
     ab    = new AddressBus;
     cpu   = new Z80(cpuClockRate_c, clockInterruptPerSecond_c);
-    h19   = new H19;
     h17   = new H17(H17_BaseAddress_c);
 
     // create the floppy drives for the hard-sectored controller.
@@ -254,7 +259,7 @@ H89::H89()
     ab->installMemory(h17ROM);
     ab->installMemory(memory);
 
-    consolePort->attachDevice(h19);
+    consolePort->attachDevice(console);
 
     cpu->setAddressBus(ab);
     cpu->setSpeed(false);
@@ -336,24 +341,14 @@ H89::~H89()
 void H89::reset()
 {
     cpu->reset();
-    h19->reset();
+    console->reset(); // TODO: does H89 reset really also reset H19?
     /// \todo reset everything, like the H17, H37, etc.
 }
 
 void H89::init()
 {
-    h19->init();
+    console->init();
     z47Cntrl->loadDisk();
-}
-
-void H89::keypress(BYTE ch)
-{
-    h19->keypress(ch);
-}
-
-void H89::display()
-{
-    h19->display();
 }
 
 void H89::enableROM()
@@ -386,11 +381,6 @@ void H89::selectSideH17(BYTE side)
 void H89::setSpeed(bool fast)
 {
     cpu->setSpeed(fast);
-}
-
-bool H89::checkUpdated()
-{
-    return (h19->checkUpdated());
 }
 
 H89Timer& H89::getTimer()
@@ -440,3 +430,6 @@ AddressBus& H89::getAddressBus()
     return (*ab);
 }
 
+// DEPRECATED
+void H89::keypress(BYTE ch) {}
+void H89::display() {}

--- a/Src/H89.h
+++ b/Src/H89.h
@@ -20,6 +20,7 @@
 
 #include "config.h"
 #include "computer.h"
+#include "Console.h"
 
 // Forward declare classes to avoid a tangled mess of includes.
 
@@ -63,7 +64,7 @@ class H89 : public Computer
     INS8250             *lpPort, *modemPort, *auxPort;
 
     H17                 *h17;
-    Terminal            *h19;
+    Console             *console;
     Z_89_37             *h37;
     Z47Interface        *z47If;
     Z47Controller       *z47Cntrl;
@@ -145,6 +146,7 @@ class H89 : public Computer
   public:
     H89();
     virtual ~H89();
+    void buildSystem(Console *console);
 
     virtual void reset();
     virtual BYTE run();
@@ -159,8 +161,6 @@ class H89 : public Computer
     virtual void lowerINT(int level);
     virtual void raiseNMI(void);
     virtual void continueCPU(void);
-
-    virtual bool checkUpdated();
 
     virtual void disableROM();
     virtual void enableROM();

--- a/Src/INS8250.cpp
+++ b/Src/INS8250.cpp
@@ -298,6 +298,11 @@ void INS8250::receiveData(BYTE data)
 
     unsigned int baud = device_m->getBaudRate();
 
+    if (baud == SerialPortDevice::DISABLE_BAUD_CHECK)
+    {
+        baud = baud_m;
+    }
+
     if (baud == baud_m)
     {
         debugss(ss8250, ALL, "%s: Baud matches\n", __FUNCTION__);

--- a/Src/SerialPortDevice.h
+++ b/Src/SerialPortDevice.h
@@ -28,6 +28,7 @@ class SerialPortDevice
     virtual void attachPort(INS8250 *port);
 
     virtual unsigned int getBaudRate() = 0;
+    static const int DISABLE_BAUD_CHECK = -1;
 
   private:
     INS8250 *port_m;

--- a/Src/StdioConsole.cpp
+++ b/Src/StdioConsole.cpp
@@ -1,0 +1,98 @@
+/// \file StdioConsole.cpp
+///
+/// \date Feb 6, 2016
+/// \author Douglas Miller
+///
+
+#include "StdioConsole.h"
+#include "logger.h"
+#include <stdio.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <signal.h>
+#include <string.h>
+#include <termios.h>
+#include <unistd.h>
+
+/// \brief StdioConsole
+///
+///
+StdioConsole::StdioConsole(int argc, char **argv): Console(argc, argv)
+{
+}
+
+StdioConsole::~StdioConsole() {}
+
+void StdioConsole::init() {}
+
+void StdioConsole::reset() {}
+
+void StdioConsole::display() {}
+
+void StdioConsole::processCharacter(char ch) {}
+
+void StdioConsole::keypress(char ch)
+{
+    if (ch == 0x0a)
+    {
+        ch = 0x0d;
+    }
+
+    sendData(ch);
+}
+
+void StdioConsole::receiveData(BYTE ch)
+{
+    static int mode = 0;
+
+    if (mode > 0)
+    {
+        if (ch == 'Z')
+        {
+            sendData('K');
+            mode = -1;
+        }
+
+        else
+        {
+            mode = 0;
+        }
+    }
+
+    else if (mode == 0 && ch == 0x1b)
+    {
+        ++mode;
+    }
+
+    else
+    {
+        fputc(ch, stdout);
+        fflush(stdout);
+    }
+}
+
+bool StdioConsole::checkUpdated()
+{
+    return false;
+}
+unsigned int StdioConsole::getBaudRate()
+{
+    return SerialPortDevice::DISABLE_BAUD_CHECK;
+}
+void StdioConsole::run()
+{
+    int ret;
+    int c;
+    struct termios termios;
+
+    setbuf(stdin, NULL);
+    tcgetattr(0, &termios);
+    termios.c_lflag &= ~ICANON;
+    termios.c_lflag &= ~ECHO;
+    tcsetattr(0, 0, &termios);
+
+    while ((c = fgetc(stdin)) != EOF)
+    {
+        keypress(c);
+    }
+}

--- a/Src/StdioConsole.h
+++ b/Src/StdioConsole.h
@@ -1,0 +1,37 @@
+/// \file StdioConsole.h
+///
+/// \date Feb 6, 2016
+/// \author Douglas Miller
+///
+
+#ifndef STDIOCONSOLE_H_
+#define STDIOCONSOLE_H_
+
+#include <assert.h>
+
+#include "config.h"
+#include "Console.h"
+
+/// \brief StdioConsole
+///
+///
+class StdioConsole : public Console
+{
+  public:
+    StdioConsole(int argc, char **argv);
+    virtual ~StdioConsole();
+
+    virtual void init();
+    virtual void reset();
+    virtual void display();
+    virtual void processCharacter(char ch);
+    virtual void keypress(char ch);
+    virtual void receiveData(BYTE);
+    virtual bool checkUpdated();
+    virtual unsigned int getBaudRate();
+    virtual void run();
+
+  private:
+};
+
+#endif // STDIOCONSOLE_H_

--- a/Src/h19.cpp
+++ b/Src/h19.cpp
@@ -3,6 +3,29 @@
 /// \date Apr 12, 2009
 /// \author Mark Garlanger
 ///
+#include "config.h"
+#include <iostream>
+#include <signal.h>
+#include <stdlib.h>
+
+#if OGL
+#ifdef __APPLE__
+#include <OpenGL/gl.h>
+#include <OpenGL/glu.h>
+#include <GLUT/glut.h>
+#else
+#include <GL/gl.h>
+#include <GL/glut.h>
+#endif
+#else
+#ifdef __APPLE__
+#include <OpenGL/gl.h>
+#else
+#include <GL/gl.h>
+#endif
+#include <wx/wx.h>
+
+#endif
 
 #include "h19.h"
 #include "h19-font.h"
@@ -21,11 +44,15 @@
 
 static  pthread_mutex_t h19_mutex;
 
+H19 *H19::h19;
+unsigned int H19::screenRefresh = screenRefresh_c;
 
-H19::H19(): updated(true),
+H19::H19(): Console(0, NULL),
+    updated(true),
     offline(false),
     curCursor(false)
 {
+    h19 = this;
     pthread_mutex_init(&h19_mutex, NULL);
     reset();
 }
@@ -57,6 +84,10 @@ bool H19::checkUpdated()
 }
 
 void H19::init()
+{
+}
+
+void H19::initGl()
 {
     GLuint i;
     glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
@@ -99,7 +130,7 @@ void H19::display()
     glRasterPos2i(0, 24 * 20);
 
     glPushAttrib(GL_LIST_BIT);
-    glListBase(fontOffset);
+    glListBase(h19->fontOffset);
     glCallLists(26 * cols, GL_UNSIGNED_INT, (GLuint *) screen);
     glPopAttrib();
     glEnable(GL_COLOR_LOGIC_OP);
@@ -1274,7 +1305,144 @@ unsigned int H19::getBaudRate()
     return (9600);
 }
 
+#if OGL
+
+void H19::reshape(int w, int h)
+{
+    glViewport(0, 0, (GLsizei) w, (GLsizei) h);
+
+    glMatrixMode(GL_PROJECTION);
+    glLoadIdentity();
+    glOrtho(0.0, w, 0.0, h, -1.0, 1.0);
+
+    glMatrixMode(GL_MODELVIEW);
+    glClearColor(0.0f, 0.0f, 0.0f, 0.9f);
+    glClear(GL_COLOR_BUFFER_BIT);
+}
+
+void H19::timer(int i)
+{
+    static int count = 0;
+
+    if ((++count % 60) == 0)
+    {
+        fflush(console_out);
+    }
+
+    // Tell glut to redisplay the scene:
+    if (h19->checkUpdated())
+    {
+        glutPostRedisplay();
+    }
+
+    // Need to call this method again after the desired amount of time has passed:
+    glutTimerFunc(screenRefresh, timer, i);
+}
+
+void H19::keyboard(unsigned char key, int x, int y)
+{
+    h19->keypress(key);
+}
+
+void H19::special(int key, int x, int y)
+{
+    // NOTE: GLUT has already differentiated exact keystrokes
+    // based on modern keyboard standards. Here we just encode
+    // the modern key codes into something convenient to use
+    // in the H19 class.
+    switch (key)
+    {
+    case GLUT_KEY_F1:
+        h19->keypress('S' | 0x80);
+        break;
+
+    case GLUT_KEY_F2:
+        h19->keypress('T' | 0x80);
+        break;
+
+    case GLUT_KEY_F3:
+        h19->keypress('U' | 0x80);
+        break;
+
+    case GLUT_KEY_F4:
+        h19->keypress('V' | 0x80);
+        break;
+
+    case GLUT_KEY_F5:
+        h19->keypress('W' | 0x80);
+        break;
+
+    case GLUT_KEY_F6:
+        h19->keypress('P' | 0x80);
+        break;
+
+    case GLUT_KEY_F7:
+        h19->keypress('Q' | 0x80);
+        break;
+
+    case GLUT_KEY_F8:
+        h19->keypress('R' | 0x80);
+        break;
+
+    case GLUT_KEY_HOME:
+        h19->keypress('H' | 0x80);
+        break;
+
+    case GLUT_KEY_UP:
+        h19->keypress('A' | 0x80);
+        break;
+
+    case GLUT_KEY_DOWN:
+        h19->keypress('B' | 0x80);
+        break;
+
+    case GLUT_KEY_LEFT:
+        h19->keypress('D' | 0x80);
+        break;
+
+    case GLUT_KEY_RIGHT:
+        h19->keypress('C' | 0x80);
+        break;
+
+    default:
+        break;
+    }
+}
+
+void H19::glDisplay()
+{
+    h19->display();
+}
+#endif
+
 void H19::run()
 {
+    int dummy_argc = 1;
+    char *dummy_argv = (char *)"dummy";
+#if OGL
+    glutInit(&dummy_argc, &dummy_argv);
+    glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGBA);
+    glutInitWindowSize(640, 500);
+    glutInitWindowPosition(500, 100);
+    glutCreateWindow((char *) "Virtual Heathkit H-89 All-in-One Computer");
 
+    glClearColor(0.0f, 0.0f, 0.0f, 0.9f);
+    //glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGBA);
+    glBlendFunc(GL_ONE, GL_ONE);
+    //glBlendEquation(GL_FUNC_ADD);
+    glBlendColor(0.5, 0.5, 0.5, 0.9);
+    //glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glEnable(GL_BLEND);
+
+    glShadeModel(GL_FLAT);
+    initGl();
+    glutReshapeFunc(reshape);
+    glutKeyboardFunc(keyboard);
+    glutSpecialFunc(special);
+    glutDisplayFunc(glDisplay);
+    glutTimerFunc(screenRefresh, timer, 1);
+    glutIgnoreKeyRepeat(1);
+
+    glutMainLoop();
+#endif  // OGL
 }

--- a/Src/h19.cpp
+++ b/Src/h19.cpp
@@ -9,6 +9,7 @@
 #include "logger.h"
 
 #include <pthread.h>
+#include <unistd.h>
 
 #ifdef __APPLE__
 #include <GLUT/glut.h>
@@ -150,7 +151,22 @@ void H19::keypress(char ch)
 
     else
     {
-        sendData(ch);
+        if ((ch & 0x80) != 0)
+        {
+            // TODO: modify keycode based on current terminal mode,
+            // e.g. convert to ZDS or ANSI codes.
+            // Note difference from H19 keyboard: a modern keyboard
+            // has separate cursor keys that are always active,
+            // so it is as if the user pressed SHIFT to get the code.
+            sendData(ascii::ESC);
+            usleep(2000);
+            sendData(ch & 0x7f);
+        }
+
+        else
+        {
+            sendData(ch);
+        }
     }
 
     pthread_mutex_unlock(&h19_mutex);

--- a/Src/h19.h
+++ b/Src/h19.h
@@ -19,14 +19,14 @@
 #include <assert.h>
 
 #include "config.h"
-#include "Terminal.h"
+#include "Console.h"
 
 /// \brief Virtual %H19 %Terminal
 ///
 /// Virtual Heathkit H19 Terminal that utilizes the GLUT framework to
 /// render a pixel accurate emulation of the terminal.
 ///
-class H19 : public Terminal//, public BaseThread
+class H19 : public Console //, public BaseThread
 {
   public:
     H19();
@@ -35,9 +35,9 @@ class H19 : public Terminal//, public BaseThread
     virtual void init();
     virtual void reset();
 
+    virtual void display();
     virtual void processCharacter(char ch);
 
-    virtual void display();
     virtual void keypress(char ch);
 
     virtual void receiveData(BYTE);
@@ -49,6 +49,15 @@ class H19 : public Terminal//, public BaseThread
     virtual void run();
 
   private:
+    static void glDisplay();
+    static void reshape(int w, int h);
+    static void timer(int i);
+    static void keyboard(unsigned char key, int x, int y);
+    static void special(int key, int x, int y);
+    static H19 *h19; // for static callback funcs
+    static const unsigned int screenRefresh_c = 1000 / 60;
+    static unsigned int screenRefresh;
+    void initGl();
 
     // screen size
     static const unsigned int cols = 80;

--- a/Src/logger.cpp
+++ b/Src/logger.cpp
@@ -50,6 +50,7 @@ void setDebugLevel()
     debugLevel[ssFloppyDisk] = defaultLevel;  // Floppy Disk
     debugLevel[ssGpp]        = defaultLevel;  // General Purpose Port
     debugLevel[ssParallel]   = defaultLevel;  // Parallel Port Interface (Z47)
+    debugLevel[ssStdioConsole] = defaultLevel;
 }
 
 void setDebug(subSystems ss, logLevel level)

--- a/Src/logger.h
+++ b/Src/logger.h
@@ -61,6 +61,7 @@ class logger
                         __PRETTY_FUNCTION__, __val);          \
                 fprintf(log_out, args);                       \
                 fprintf(log_out,"\x1b[0m");                   \
+                fflush(log_out);                   \
             }                                                 \
         }
 
@@ -114,6 +115,7 @@ enum subSystems
     ssFloppyDisk,
     ssGpp,
     ssParallel,
+    ssStdioConsole,
     ssMax
 };
 

--- a/Src/main.cpp
+++ b/Src/main.cpp
@@ -159,22 +159,62 @@ void keyboard(unsigned char key, int x, int y)
 
 void special(int key, int x, int y)
 {
+    // NOTE: GLUT has already differentiated exact keystrokes
+    // based on modern keyboard standards. Here we just encode
+    // the modern key codes into something convenient to use
+    // in the H19 class.
     switch (key)
     {
+    case GLUT_KEY_F1:
+        h89.keypress('S' | 0x80);
+        break;
+
+    case GLUT_KEY_F2:
+        h89.keypress('T' | 0x80);
+        break;
+
+    case GLUT_KEY_F3:
+        h89.keypress('U' | 0x80);
+        break;
+
+    case GLUT_KEY_F4:
+        h89.keypress('V' | 0x80);
+        break;
+
+    case GLUT_KEY_F5:
+        h89.keypress('W' | 0x80);
+        break;
+
+    case GLUT_KEY_F6:
+        h89.keypress('P' | 0x80);
+        break;
+
+    case GLUT_KEY_F7:
+        h89.keypress('Q' | 0x80);
+        break;
+
+    case GLUT_KEY_F8:
+        h89.keypress('R' | 0x80);
+        break;
+
+    case GLUT_KEY_HOME:
+        h89.keypress('H' | 0x80);
+        break;
+
     case GLUT_KEY_UP:
-        h89.keypress('8');
+        h89.keypress('A' | 0x80);
         break;
 
     case GLUT_KEY_DOWN:
-        h89.keypress('2');
+        h89.keypress('B' | 0x80);
         break;
 
     case GLUT_KEY_LEFT:
-        h89.keypress('4');
+        h89.keypress('D' | 0x80);
         break;
 
     case GLUT_KEY_RIGHT:
-        h89.keypress('6');
+        h89.keypress('C' | 0x80);
         break;
 
     default:


### PR DESCRIPTION
…ernate ESC codes.

It works, at least for MMS system utilities. Right now it ignores any terminal settings like keypad mode and alternate ESC codes. I had a problem with the two-char sequences causing overrun in the serial device, so I added a usleep(2000) (2mS) between. I did not try other values or work out an alternate scheme. With no flow-control it's difficult.

Mapped F1-F5, cursor and HOME, and F6->BLUE, F7->RED, F->GRAY.
