### PR TITLE
Fix uncrustify config to allow not processing sections.

### DIFF
--- a/VirtualH89/uncrust.cfg
+++ b/VirtualH89/uncrust.cfg
@@ -27,11 +27,6 @@ string_replace_tab_chars                  = false    # false/true
 # Improvements to template detection may make this option obsolete.
 tok_split_gte                             = false    # false/true
 
-# Override the default ' *INDENT-OFF*' in comments for disabling processing of part of the file.
-disable_processing_cmt                    = ""         # string
-
-# Override the default ' *INDENT-ON*' in comments for enabling processing of part of the file.
-enable_processing_cmt                     = ""         # string
 
 # Enable parsing of digraphs. Default=false
 enable_digraphs                           = false    # false/true


### PR DESCRIPTION
The auto generated config file included overriding '_INDENT-OFF_', without putting anything in it, so section skipping was not working.
