### PR TITLE
Cleanup CP/Net support and add CP/M Plus capabilities.

### DIFF
--- a/VirtualH89/Src/CPNetDevice.h
+++ b/VirtualH89/Src/CPNetDevice.h
@@ -36,9 +36,10 @@ class CPNetDevice: public IODevice
     int sendMsg(BYTE* msgbuf, int len);
     int checkRecvMsg(BYTE clientId, BYTE* msgbuf, int len);
 
+    static const int  ndosLen = sizeof(struct NetworkServer::ndos);
     BYTE              clientId;
     const char*       dir;
-    BYTE              buffer[256 + sizeof(struct NetworkServer::ndos)];
+    BYTE              buffer[256 + ndosLen];
     struct            NetworkServer::ndos* header;
     int               bufIx;
     int               msgLen;

--- a/VirtualH89/Src/HostFileBdos.cpp
+++ b/VirtualH89/Src/HostFileBdos.cpp
@@ -851,8 +851,8 @@ HostFileBdos::readFStamps(uint8_t* msgbuf, int len)
     stat(pathName, &stb);
     fcb->ext = 0; // no passwords
     // order is important, overwrites seconds field (not present in CP/M 3 timestamps).
-    unix2cpmdate(stb.st_atim.tv_sec, (struct cpmdate*) &fcb->d0[8]);
-    unix2cpmdate(stb.st_mtim.tv_sec, (struct cpmdate*) &fcb->d0[12]);
+    unix2cpmdate(stb.st_atime, (struct cpmdate*) &fcb->d0[8]);
+    unix2cpmdate(stb.st_mtime, (struct cpmdate*) &fcb->d0[12]);
     fcb->cr = 0;
     return 37;
 }
@@ -1209,9 +1209,9 @@ HostFileBdos::commonSearch(struct search* search)
             // extent info is not computed until copyOut.
             int x = search->iter & 0x03; // 0, 1, 2 only
             // order is imperative, overwrite seconds field
-            unix2cpmdate(stb.st_atim.tv_sec,
+            unix2cpmdate(stb.st_atime,
                          (struct cpmdate*) &sFcb.fcbs[x].atim);
-            unix2cpmdate(stb.st_mtim.tv_sec,
+            unix2cpmdate(stb.st_mtime,
                          (struct cpmdate*) &sFcb.fcbs[x].utim);
             sFcb.fcbs[x].pwmode = 0; // clear seconds overrun
         }

--- a/VirtualH89/Src/HostFileBdos.h
+++ b/VirtualH89/Src/HostFileBdos.h
@@ -9,61 +9,109 @@
 #ifndef HOSTFILEBDOS_H_
 #define HOSTFILEBDOS_H_
 
-#include "config.h"
-#include "h89Types.h"
 #include "NetworkServer.h"
 #include "propertyutil.h"
 
 #include <dirent.h>
 #include <string>
 
-#define BDOS_FUNC(name)                                            \
-    int name(BYTE * msgbuf, int len);                              \
-    static int name(HostFileBdos * thus, BYTE * msgbuf, int len) { \
-        return thus->name(msgbuf, len);                            \
+#define BDOS_FUNC(name)                                               \
+    int name(uint8_t * msgbuf, int len);                              \
+    static int name(HostFileBdos * thus, uint8_t * msgbuf, int len) { \
+        return thus->name(msgbuf, len);                               \
     }
+
+// An instance of HostFileBdos represents a client-server pair.
+// This is typically a dedicated network connection (e.g. socket),
+// but may also be an informal pairing such as a virtual machine's
+// "connection" to the native host.
 
 class HostFileBdos: public NetworkServer
 {
   public:
     HostFileBdos(PropertyUtil::PropertyMapT& props,
-                 std::vector<std::string> args, BYTE srvId);
+                 std::vector<std::string> args, uint8_t srvId, uint8_t cltId);
     virtual ~HostFileBdos();
 
-    virtual int checkRecvMsg(BYTE clientId, BYTE* msgbuf, int len);
-    virtual int sendMsg(BYTE* msgbuf, int len);
-
+    virtual int checkRecvMsg(uint8_t clientId, uint8_t* msgbuf, int len);
+    virtual int sendMsg(uint8_t* msgbuf, int len);
   private:
-    const char* dir;
-    BYTE        serverId;
+    char*   dir;
+    uint8_t serverId;
+    uint8_t clientId;
 
     struct fcb
     {
-        BYTE drv;
-        BYTE name[11];
-        BYTE ext;
-        BYTE s1[2];
-        BYTE rc;
+        uint8_t drv;
+        uint8_t name[11];
+        uint8_t ext;
+        uint8_t s1[2];
+        uint8_t rc;
         union
         {
-            BYTE d0[16];
+            uint8_t d0[16];
             struct
             {
-                int fd;
-                int oflags;
+                uint16_t fd;
+                uint16_t fd_;
+                int      oflags;
             };
         };
-        BYTE cr;
-        BYTE rr[3];
+        uint8_t cr;
+        uint8_t rr[3];
+    } __attribute__((packed));
+
+    struct fcbdate
+    {
+        uint16_t date;
+        uint8_t  hour, min;
+    } __attribute__((packed));
+
+    struct cpmdate
+    {
+        uint16_t date;
+        uint8_t  hour, min, sec;
+    } __attribute__((packed));
+
+    struct sfcbs
+    {
+        struct fcbdate atim;
+        struct fcbdate utim;
+        uint8_t        pwmode;
+        uint8_t        reserved;
+    } __attribute__((packed));
+
+    struct sfcb
+    {
+        uint8_t      drv; // always 0x21
+        struct sfcbs fcbs[3];
+        uint8_t      reserved;
+    } __attribute__((packed));
+
+    struct dirl
+    {
+        uint8_t        drv;    // always 0x20
+        uint8_t        name[11];
+        uint8_t        ext;    // mode byte
+        uint8_t        s1[2];  // 0x00 0x00
+        uint8_t        rc;     // 0x00
+        uint8_t        pwd[8]; // password
+        struct fcbdate ctim;
+        struct fcbdate utim;
     } __attribute__((packed));
 
     struct search
     {
-        int   iter;
-        BYTE  drv;
-        BYTE  usr;
-        BYTE  ext;
-        off_t size;
+        int     iter;
+        int     lastit;
+        int     endit;
+        uint8_t maxdc; // 3 or 4, depending on timestamps (SFCBs)
+        uint8_t drv;
+        uint8_t usr;
+        uint8_t ext;
+        uint8_t full;
+        uint8_t cpm3;
+        off_t   size;
         struct find
         {
             DIR* dir;
@@ -75,32 +123,39 @@ class HostFileBdos: public NetworkServer
 
     struct dpb
     {
-        WORD spt;
-        BYTE bsh;
-        BYTE blm;
-        BYTE exm;
-        WORD dsm;
-        WORD drm;
-        BYTE al0;
-        BYTE al1;
-        WORD cks;
-        WORD off;
+        uint16_t spt;
+        uint8_t  bsh;
+        uint8_t  blm;
+        uint8_t  exm;
+        uint16_t dsm;
+        uint16_t drm;
+        uint8_t  al0;
+        uint8_t  al1;
+        uint16_t cks;
+        uint16_t off;
     } __attribute__((packed));
 
-    static const int DEF_BLS_SH  = 14;  // 2^14 = 16K
-    static const int DEF_BLS     = (1 << DEF_BLS_SH);
-    static const int DEF_NBLOCKS = 128; // keep alloc vec small, disk size 2M
+    static const int     DEF_BLS_SH  = 14;  // 2^14 = 16K
+    static const int     DEF_BLS     = (1 << DEF_BLS_SH);
+    static const int     DEF_NBLOCKS = 128; // keep alloc vec small, disk size 2M
+    static const int     DEF_NFILE   = 32;  // Probably never need even 8.
+    static const uint8_t dirMode     = 0b01100001;
 
-    static int (*bdosFunctions[256])(HostFileBdos*, BYTE*, int);
+    static int(*bdosFunctions[256])(HostFileBdos*, uint8_t*, int);
 
-    WORD             curDma;
-    void*            curDmaReal;
-    WORD             curDsk;
-    WORD             curUsr;
-    WORD             curROVec;
-    WORD             curLogVec;
-    struct search    curSearch;
-    struct dpb       curDpb;
+    uint16_t             curDma;
+    void*                curDmaReal;
+    uint16_t             curDsk;
+    uint16_t             curUsr;
+    uint16_t             curROVec;
+    uint16_t             curLogVec;
+    struct search        curSearch;
+    struct dpb           curDpb;
+    int                  phyExt; // phy ext size, recs
+    int                  openFiles[DEF_NFILE];
+    char                 fileName[sizeof((struct dirent*) 0)->d_name];
+    char                 pathName[PATH_MAX];
+    struct sfcb          sFcb;
 
     BDOS_FUNC(getDPB);
     BDOS_FUNC(writeProt);
@@ -126,12 +181,19 @@ class HostFileBdos: public NetworkServer
     BDOS_FUNC(accessDrive);
     BDOS_FUNC(freeDrive);
     BDOS_FUNC(writeRandZF);
+    BDOS_FUNC(lockRec);
     BDOS_FUNC(unlockRec);
+    BDOS_FUNC(getFreeSp);
+    BDOS_FUNC(flushBuf);
+    BDOS_FUNC(freeBlks);
+    BDOS_FUNC(truncFile);
     BDOS_FUNC(login);
     BDOS_FUNC(logoff);
     BDOS_FUNC(setCompAttrs);
     BDOS_FUNC(getServCfg);
     BDOS_FUNC(setDefPwd);
+    BDOS_FUNC(getDirLab);
+    BDOS_FUNC(readFStamps);
     BDOS_FUNC(getTime);
 
     // Utility functions
@@ -140,17 +202,25 @@ class HostFileBdos: public NetworkServer
     int cpmPath(char* buf, int drive, int user, char* file);
     char* cpmNameFound(struct search::find* find);
     char* cpmPathFound(struct search::find* find);
-    char* cpmFindInit(struct search::find* find);
-    char* cpmFind(struct search::find* find, int drive, char* pattern);
+    void cpmFindInit(struct search::find* find, int drive, char* pattern);
+    const char* cpmFind(struct search::find* find);
     void getFileName(char* dst, struct fcb* fcb);
     void getAmbFileName(char* dst, struct fcb* fcb, uint8_t usr);
-    void copyOutDir(BYTE* dma, char* name);
-    void copyOutSearch(BYTE* buf, char* name);
-    char* commonSearch(struct search* search, char* pat);
-    char* doSearch(struct search* search);
-    char* startSearch(struct fcb* fcb, struct search* search, BYTE u);
+    void copyOutDir(uint8_t* dma, const char* name);
+    int fullSearch(uint8_t* dirbuf, struct search* search, const char* ff);
+    int copyOutSearch(uint8_t* buf, const char* name);
+    const char* commonSearch(struct search* search);
+    const char* doSearch(struct search* search);
+    const char* startSearch(struct fcb* fcb, struct search* search, uint8_t u);
     void seekFile(struct fcb* fcb);
-    int openFileFcb(struct fcb* fcb, BYTE u);
+    int openFileFcb(struct fcb* fcb, uint8_t u);
+    int newFileFcb();
+    int locFileFcb(struct fcb* fcb);
+    void putFileFcb(struct fcb* fcb, int ix, int fd);
+    int getFileFcb(struct fcb* fcb);
+    int closeFileFcb(struct fcb* fcb);
+    int makeFileFcb(struct fcb* fcb, uint8_t u);
+    void unix2cpmdate(time_t unx, struct cpmdate* cpm);
 
 };
 

--- a/VirtualH89/Src/NetworkServer.h
+++ b/VirtualH89/Src/NetworkServer.h
@@ -10,8 +10,7 @@
 #ifndef NETWORKSERVER_H_
 #define NETWORKSERVER_H_
 
-#include "config.h"
-#include "h89Types.h"
+#include <stdint.h>
 
 class NetworkServer
 {
@@ -19,19 +18,18 @@ class NetworkServer
     NetworkServer();
     virtual ~NetworkServer();
 
-    virtual int checkRecvMsg(BYTE clientId, BYTE* msgbuf, int len) = 0;
-    virtual int sendMsg(BYTE* msgbuf, int len)                     = 0;
+    virtual int checkRecvMsg(uint8_t clientId, uint8_t* msgbuf, int len) = 0;
+    virtual int sendMsg(uint8_t* msgbuf, int len)                        = 0;
 
     // This is the standard CP/Net message header.
     struct ndos
     {
-        BYTE mcode; // cmd=00, response=01, for CP/Net
-        BYTE mdid;
-        BYTE msid;
-        BYTE mfunc;
-        BYTE msize; // size is msize+1 (1-256 bytes)
+        uint8_t mcode; // cmd=00, response=01, for CP/Net
+        uint8_t mdid;
+        uint8_t msid;
+        uint8_t mfunc;
+        uint8_t msize; // size is msize+1 (1-256 bytes)
     };
-
   private:
 };
 


### PR DESCRIPTION
These changes require that the compile use "-D__H89__" in order to compile the CP/Net files for the VirtualH89 environment. The files may now be compiled in a pure-Unix environment so that a Unix-based CP/Net server could be built, which does not have things like "logger" and "h89Types".
