### PR TITLE
Revert "Reduce amount of inlined debug code."

### DIFF
--- a/VirtualH89/Src/logger.cpp
+++ b/VirtualH89/Src/logger.cpp
@@ -4,20 +4,22 @@
 /// \author Mark Garlanger
 ///
 
-#include <stdarg.h>
-
 #include "logger.h"
 
+
 unsigned debugLevel[ssMax];
+
 
 logger::logger():  printToFile(false),
                    printToScreen(false),
                    logFile(NULL)
 {
+
 }
 
 logger::~logger()
 {
+
 }
 
 void
@@ -26,6 +28,8 @@ setDebugLevel()
     logLevel defaultLevel = ERROR;
 
     debugLevel[ssH89]                 = defaultLevel; // The overall H89
+    debugLevel[ssMEM]                 = defaultLevel; // Memory class
+    debugLevel[ssRAM]                 = defaultLevel; // RAM accesses
     debugLevel[ssROM]                 = defaultLevel; // ROM accesses
     debugLevel[ssZ80]                 = defaultLevel; // Z80 CPU
     debugLevel[ssInterruptController] = defaultLevel; // Interrupt Controller
@@ -44,7 +48,7 @@ setDebugLevel()
     debugLevel[ss8250]                = defaultLevel; // 8250 Serial Port
     debugLevel[ssTimer]               = defaultLevel; // 2 mSec Timer
     debugLevel[ssWallClock]           = defaultLevel; // Wall Clock.
-    // debugLevel[ssDiskDrive] = defaultLevel;  // Disk Drive
+    // debugLevel[ssDiskDrive]  = defaultLevel;  // Disk Drive
     debugLevel[ssFloppyDisk]          = defaultLevel; // Floppy Disk
     debugLevel[ssGpp]                 = defaultLevel; // General Purpose Port
     debugLevel[ssParallel]            = defaultLevel; // Parallel Port Interface (Z47)
@@ -61,42 +65,8 @@ setDebugLevel()
 }
 
 void
-setDebug(subSystems ss, logLevel level)
+setDebug(subSystems ss,
+         logLevel   level)
 {
     debugLevel[ss] = level;
-}
-
-void
-__debugss(enum subSystems subsys, enum logLevel level, const char* fmt, ...)
-{
-    va_list vl;
-    int     __val = 0;
-    if (level < ERROR)
-    {
-        __val = 31; /* FATAL = Red */
-    }
-    else if (level < WARNING)
-    {
-        __val = 33; /* ERROR = Yellow */
-    }
-    else if (level < INFO)
-    {
-        __val = 35; /* WARNING = Magenta */
-    }
-    else if (level < VERBOSE)
-    {
-        __val = 34; /* INFO = Blue */
-    }
-    else
-    {
-        __val = 32; /* default = Green */
-    }
-    fprintf(log_out, "\x1b[37m");
-    WallClock::instance()->printTime(log_out);
-    fprintf(log_out, "\x1b[36m%s: \x1b[%dm", __PRETTY_FUNCTION__, __val);
-    va_start(vl, fmt);
-    vfprintf(log_out, fmt, vl);
-    va_end(vl);
-    fprintf(log_out, "\x1b[0m");
-    fflush(log_out);
 }

--- a/VirtualH89/Src/logger.h
+++ b/VirtualH89/Src/logger.h
@@ -21,21 +21,79 @@ extern FILE* console_out;
 class logger
 {
   public:
+
   private:
     logger();
     ~logger();
     bool  printToFile;
     bool  printToScreen;
     FILE* logFile;
+
 };
 
 #define DEBUG 1
 #define DEBUG_TO_FILE 1
+#if DEBUG
+
+#if DEBUG_TO_FILE
+// #define debug(cond, ...)   if (cond) { printf(__VA_ARGS__); }
+
+#define debug(...)         {if (log_out){fprintf(log_out, __VA_ARGS__); }}
+
+#define debugss(subsys, level, args ...)               \
+    {                                                  \
+        int __val = 0;                                 \
+        if (level <= debugLevel[subsys])               \
+        {                                              \
+            if (level < ERROR)                         \
+            {__val = 31; } /* Red */                   \
+            else if (level < WARNING)                  \
+            {__val = 33; } /* Yellow */                \
+            else if (level < INFO)                     \
+            {__val = 35; } /* Magenta */               \
+            else if (level < VERBOSE)                  \
+            {__val = 34; } /* Blue */                  \
+            else                                       \
+            {__val = 32; } /* Green */                 \
+            fprintf(log_out, "\x1b[37m");              \
+            WallClock::instance()->printTime(log_out); \
+            fprintf(log_out, "\x1b[36m%s: \x1b[%dm",   \
+                    __PRETTY_FUNCTION__, __val);       \
+            fprintf(log_out, args);                    \
+            fprintf(log_out, "\x1b[0m");               \
+            fflush(log_out);                           \
+        }                                              \
+    }
+
+
+// nts - No TimeStamp
+#define debugss_nts(subsys, level, args ...) \
+    {                                        \
+        if (level <= debugLevel[subsys])     \
+        {                                    \
+            fprintf(log_out, args);          \
+        }                                    \
+    }
+
+#define chkdebuglevel(subsys, level)  ((level <= debugLevel[subsys]))
+
+#else
+#define cond_debug(cond, ...)   if (cond){printf(__VA_ARGS__); }
+#define debug(args ...)              {printf(args); }
+#endif
+#else
+#define debug(args ...)
+#define debugss(subsys, level, args ...)
+#define debugss_nts(subsys, level, args ...)
+#define chkdebuglevel(subsys, level) (false)
+#endif
 
 ///
 enum subSystems
 {
     ssH89,
+    ssMEM,
+    ssRAM,
     ssROM,
     ssZ80,
     ssInterruptController,
@@ -94,47 +152,12 @@ enum logLevel
     ALL     = 100
 };
 
-#if DEBUG
-
-#if DEBUG_TO_FILE
-// #define debug(cond, ...)   if (cond) { printf(__VA_ARGS__); }
-
-#define debug(...)         {if (log_out){fprintf(log_out, __VA_ARGS__); }}
-
-extern void __debugss(enum subSystems, enum logLevel, const char* fmt, ...);
-#define debugss(subsys, level, args ...) \
-    if (level <= debugLevel[subsys])     \
-    {                                    \
-        __debugss(subsys, level, args);  \
-    }
-
-
-// nts - No TimeStamp
-#define debugss_nts(subsys, level, args ...) \
-    {                                        \
-        if (level <= debugLevel[subsys])     \
-        {                                    \
-            fprintf(log_out, args);          \
-        }                                    \
-    }
-
-#define chkdebuglevel(subsys, level)  ((level <= debugLevel[subsys]))
-
-#else // if !DEBUG_TO_FILE
-#define cond_debug(cond, ...)   if (cond){printf(__VA_ARGS__); }
-#define debug(args ...)              {printf(args); }
-#endif // DEBUG_TO_FILE
-#else   // if !DEBUG
-#define debug(args ...)
-#define debugss(subsys, level, args ...)
-#define debugss_nts(subsys, level, args ...)
-#define chkdebuglevel(subsys, level) (false)
-#endif // DEBUG
-
 extern unsigned debugLevel[ssMax];
 
 void setDebugLevel();
 
-void setDebug(subSystems ss, logLevel level);
+void setDebug(subSystems ss,
+              logLevel   level);
+
 
 #endif // LOGGER_H_


### PR DESCRIPTION
Reverts mgarlanger/VirtualH89#20

Reverting this due to loss of functionality - prior output looked like this: 
00002.654:0388 - int GenericFloppyDrive::readData(bool, BYTE, BYTE, BYTE, int): readData: read passed - pos(512) data(-247)

with this change, the output looks like:
00003.747:0824 - void __debugss(enum subSystems, enum logLevel, const char *, ...): readData: read passed - track(3) sector(3) pos(511) data(229)
- it no longer print the function name/parameters, instead always shows __debugss().
