### PR TITLE
Fix bug in Z80 "ld (ix+d),n" instruction.

### DIFF
--- a/VirtualH89/Src/z80.cpp
+++ b/VirtualH89/Src/z80.cpp
@@ -2605,7 +2605,12 @@ Z80::op_ld_ihl_x(void)
 void
 Z80::op_ld_ihl_n(void)
 {
-    writeMEM(getIndirectAddr(), READn());
+    // Order is imperative here for DD/FD instructions:
+    // displacement is 3rd byte and value is 4th.
+    // Functions with side-effects can be dangerous.
+    WORD adr = getIndirectAddr();
+    BYTE n = READn();
+    writeMEM(adr, n);
 }
 
 ///


### PR DESCRIPTION
Not sure if there are other instances of this same bug, but wanted to fix the instruction I knew about. Basically, the code:

```
    writeMEM(getIndirectAddr(), READn());
```

is not deterministic about which of "getIndirectAddr" or "READn" are called first, yet they both have crucial side-effects in the case of DD/FD (IX/IY) instructions. Most compilers tend to work from right to left on function parameters, so on most machines these functions are being called in the exact wrong order since the Z80 instruction has the displacement (getIndirectAddr) before immediate value (READn), and the compiler will call them in a different order.

This may not be a very popular instruction. It is used in MMS code, although most-heavily in code for the 77422 firmware or the 77500 server.
