### PR TITLE
Fix PRINTER-AUX serial port association.

### DIFF
--- a/VirtualH89/Src/H89.h
+++ b/VirtualH89/Src/H89.h
@@ -122,9 +122,9 @@ class H89: public Computer
     /// Addresses for the serial ports
     static const BYTE          Serial_Console_c           = 0350; // (0xe8)
     static const BYTE          Serial_Console_Interrupt_c = 3;
-    static const BYTE          Serial_LpPort_c            = 0320;
+    static const BYTE          Serial_AuxPort_c           = 0320;
     static const BYTE          Serial_ModemPort_c         = 0330;
-    static const BYTE          Serial_AuxPort_c           = 0340;
+    static const BYTE          Serial_LpPort_c            = 0340;
 
     /// Address for NMI
     /// Octal 360-361 and 372-373


### PR DESCRIPTION
Discovered this while trying to work on a printer emulation. The ports numbers for AUX and LP are swapped.
