### PR TITLE
H37, memory , and other fixes.

### DIFF
--- a/VirtualH89.xcodeproj/project.pbxproj
+++ b/VirtualH89.xcodeproj/project.pbxproj
@@ -29,6 +29,13 @@
 		A13C989D1C7A3850000CF03B /* RawFloppyImage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A13C989B1C7A3850000CF03B /* RawFloppyImage.cpp */; };
 		A13C98A01C7A385C000CF03B /* wd1797.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A13C989E1C7A385C000CF03B /* wd1797.cpp */; };
 		A15861A91CB8DCE500D3382D /* WD179xUserIf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A15861A71CB8DCE500D3382D /* WD179xUserIf.cpp */; };
+		A192FCD91CDFB68100B4E8D5 /* Memory8K.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A192FCD81CDFB68100B4E8D5 /* Memory8K.cpp */; };
+		A192FCDB1CDFB7EF00B4E8D5 /* Memory64k.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A192FCDA1CDFB7EF00B4E8D5 /* Memory64k.cpp */; };
+		A192FCDD1CDFBF7800B4E8D5 /* MemoryLayout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A192FCDC1CDFBF7800B4E8D5 /* MemoryLayout.cpp */; };
+		A192FCDF1CDFC27400B4E8D5 /* H88MemoryLayout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A192FCDE1CDFC27400B4E8D5 /* H88MemoryLayout.cpp */; };
+		A192FCE11CDFC43E00B4E8D5 /* HDOSMemory8K.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A192FCE01CDFC43E00B4E8D5 /* HDOSMemory8K.cpp */; };
+		A192FCE31CDFFB2500B4E8D5 /* Z64KMemoryLayout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A192FCE21CDFFB2500B4E8D5 /* Z64KMemoryLayout.cpp */; };
+		A192FCE51CE00A7800B4E8D5 /* MemoryDecoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A192FCE41CE00A7800B4E8D5 /* MemoryDecoder.cpp */; };
 		A1A434371C7060430015F838 /* AddressBus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A1A433D01C7060430015F838 /* AddressBus.cpp */; };
 		A1A434381C7060430015F838 /* ClockUser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A1A433D41C7060430015F838 /* ClockUser.cpp */; };
 		A1A434391C7060430015F838 /* computer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A1A433D61C7060430015F838 /* computer.cpp */; };
@@ -77,6 +84,7 @@
 		A1A4346B1C7197F70015F838 /* GLUT.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1A434671C7063CF0015F838 /* GLUT.framework */; };
 		A1CA80A21CC20F7D004A11B7 /* IOBus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A1CA80A01CC20F7D004A11B7 /* IOBus.cpp */; };
 		A1CA80A51CC46F5E004A11B7 /* IMDFloppyDisk.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A1CA80A31CC46F5E004A11B7 /* IMDFloppyDisk.cpp */; };
+		A1CA80A81CD73EAE004A11B7 /* TD0FloppyDisk.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A1CA80A61CD73EAE004A11B7 /* TD0FloppyDisk.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -146,6 +154,13 @@
 		A13C989F1C7A385C000CF03B /* wd1797.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = wd1797.h; sourceTree = "<group>"; };
 		A15861A71CB8DCE500D3382D /* WD179xUserIf.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WD179xUserIf.cpp; sourceTree = "<group>"; };
 		A15861A81CB8DCE500D3382D /* WD179xUserIf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WD179xUserIf.h; sourceTree = "<group>"; };
+		A192FCD81CDFB68100B4E8D5 /* Memory8K.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Memory8K.cpp; sourceTree = "<group>"; };
+		A192FCDA1CDFB7EF00B4E8D5 /* Memory64k.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Memory64k.cpp; sourceTree = "<group>"; };
+		A192FCDC1CDFBF7800B4E8D5 /* MemoryLayout.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MemoryLayout.cpp; sourceTree = "<group>"; };
+		A192FCDE1CDFC27400B4E8D5 /* H88MemoryLayout.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = H88MemoryLayout.cpp; sourceTree = "<group>"; };
+		A192FCE01CDFC43E00B4E8D5 /* HDOSMemory8K.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HDOSMemory8K.cpp; sourceTree = "<group>"; };
+		A192FCE21CDFFB2500B4E8D5 /* Z64KMemoryLayout.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Z64KMemoryLayout.cpp; sourceTree = "<group>"; };
+		A192FCE41CE00A7800B4E8D5 /* MemoryDecoder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MemoryDecoder.cpp; sourceTree = "<group>"; };
 		A1A433C01C705D310015F838 /* VirtualH89 */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = VirtualH89; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1A433CB1C7060430015F838 /* doxygen.conf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = doxygen.conf; sourceTree = "<group>"; };
 		A1A433CC1C7060430015F838 /* generateDoxy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = generateDoxy; sourceTree = "<group>"; };
@@ -251,6 +266,8 @@
 		A1CA80A11CC20F7D004A11B7 /* IOBus.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IOBus.h; sourceTree = "<group>"; };
 		A1CA80A31CC46F5E004A11B7 /* IMDFloppyDisk.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IMDFloppyDisk.cpp; sourceTree = "<group>"; };
 		A1CA80A41CC46F5E004A11B7 /* IMDFloppyDisk.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IMDFloppyDisk.h; sourceTree = "<group>"; };
+		A1CA80A61CD73EAE004A11B7 /* TD0FloppyDisk.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TD0FloppyDisk.cpp; sourceTree = "<group>"; };
+		A1CA80A71CD73EAE004A11B7 /* TD0FloppyDisk.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TD0FloppyDisk.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -375,6 +392,7 @@
 				A1A433FC1C7060430015F838 /* H47Drive.h */,
 				A13BEE6A1C96957F00C7E65A /* H88MemoryDecoder.cpp */,
 				A13BEE6B1C96957F00C7E65A /* H88MemoryDecoder.h */,
+				A192FCDE1CDFC27400B4E8D5 /* H88MemoryLayout.cpp */,
 				A13BEE6C1C96957F00C7E65A /* H88MemoryLayout.h */,
 				A1A433FD1C7060430015F838 /* h89-io.cpp */,
 				A1A433FE1C7060430015F838 /* h89-io.h */,
@@ -390,9 +408,12 @@
 				A1A434041C7060430015F838 /* h89Types.h */,
 				A1A434051C7060430015F838 /* HardSectoredDisk.cpp */,
 				A1A434061C7060430015F838 /* HardSectoredDisk.h */,
+				A192FCE01CDFC43E00B4E8D5 /* HDOSMemory8K.cpp */,
 				A13BEE711C96959F00C7E65A /* HDOSMemory8K.h */,
 				A13BEE721C96959F00C7E65A /* HostFileBdos.cpp */,
 				A13BEE731C96959F00C7E65A /* HostFileBdos.h */,
+				A1CA80A31CC46F5E004A11B7 /* IMDFloppyDisk.cpp */,
+				A1CA80A41CC46F5E004A11B7 /* IMDFloppyDisk.h */,
 				A1A434071C7060430015F838 /* INS8250.cpp */,
 				A1A434081C7060430015F838 /* INS8250.h */,
 				A1A434091C7060430015F838 /* InterruptController.cpp */,
@@ -406,9 +427,13 @@
 				A1A4340F1C7060430015F838 /* logger.h */,
 				A1A434101C7060430015F838 /* main.cpp */,
 				A1A434111C7060430015F838 /* main.h */,
+				A192FCD81CDFB68100B4E8D5 /* Memory8K.cpp */,
 				A13BEE751C9695AC00C7E65A /* Memory8K.h */,
+				A192FCDA1CDFB7EF00B4E8D5 /* Memory64k.cpp */,
 				A13BEE761C9695AC00C7E65A /* Memory64K.h */,
+				A192FCE41CE00A7800B4E8D5 /* MemoryDecoder.cpp */,
 				A13BEE771C9695AC00C7E65A /* MemoryDecoder.h */,
+				A192FCDC1CDFBF7800B4E8D5 /* MemoryLayout.cpp */,
 				A13BEE781C9695AC00C7E65A /* MemoryLayout.h */,
 				A13C988F1C7A382D000CF03B /* MMS316IntrCtrlr.cpp */,
 				A13C98901C7A382D000CF03B /* MMS316IntrCtrlr.h */,
@@ -448,6 +473,8 @@
 				A1A434291C7060430015F838 /* StdioConsole.h */,
 				A13C98981C7A3839000CF03B /* StdioProxyConsole.cpp */,
 				A13C98991C7A3839000CF03B /* StdioProxyConsole.h */,
+				A1CA80A61CD73EAE004A11B7 /* TD0FloppyDisk.cpp */,
+				A1CA80A71CD73EAE004A11B7 /* TD0FloppyDisk.h */,
 				A1A4342A1C7060430015F838 /* Terminal.cpp */,
 				A1A4342B1C7060430015F838 /* Terminal.h */,
 				A1A4342C1C7060430015F838 /* Track.cpp */,
@@ -462,11 +489,10 @@
 				A1A434311C7060430015F838 /* Z47Controller.h */,
 				A1A434321C7060430015F838 /* Z47Interface.cpp */,
 				A1A434331C7060430015F838 /* Z47Interface.h */,
+				A192FCE21CDFFB2500B4E8D5 /* Z64KMemoryLayout.cpp */,
 				A13BEE691C96957500C7E65A /* Z64KMemoryLayout.h */,
 				A1A434341C7060430015F838 /* z80.cpp */,
 				A1A434351C7060430015F838 /* z80.h */,
-				A1CA80A31CC46F5E004A11B7 /* IMDFloppyDisk.cpp */,
-				A1CA80A41CC46F5E004A11B7 /* IMDFloppyDisk.h */,
 			);
 			path = Src;
 			sourceTree = "<group>";
@@ -527,6 +553,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A192FCDD1CDFBF7800B4E8D5 /* MemoryLayout.cpp in Sources */,
 				A1A4345E1C7060430015F838 /* StdioConsole.cpp in Sources */,
 				A1A434371C7060430015F838 /* AddressBus.cpp in Sources */,
 				A13C98891C7A3805000CF03B /* GenericFloppyDisk.cpp in Sources */,
@@ -550,13 +577,16 @@
 				A1A4344B1C7060430015F838 /* h89-timer.cpp in Sources */,
 				A13BEE831C9695D100C7E65A /* SectorFloppyImage.cpp in Sources */,
 				A1A434571C7060430015F838 /* propertyutil.cpp in Sources */,
+				A192FCE31CDFFB2500B4E8D5 /* Z64KMemoryLayout.cpp in Sources */,
 				A1A434521C7060430015F838 /* main.cpp in Sources */,
+				A192FCE11CDFC43E00B4E8D5 /* HDOSMemory8K.cpp in Sources */,
 				A1A4344E1C7060430015F838 /* INS8250.cpp in Sources */,
 				A13C987E1C7A37F7000CF03B /* DiskController.cpp in Sources */,
 				A13C988A1C7A3805000CF03B /* GenericFloppyDrive.cpp in Sources */,
 				A1A434401C7060430015F838 /* EightInchDisk.cpp in Sources */,
 				A1A434551C7060430015F838 /* ParallelLink.cpp in Sources */,
 				A1A4345F1C7060430015F838 /* Terminal.cpp in Sources */,
+				A192FCDB1CDFB7EF00B4E8D5 /* Memory64k.cpp in Sources */,
 				A1A434441C7060430015F838 /* h-17-1.cpp in Sources */,
 				A13C98A01C7A385C000CF03B /* wd1797.cpp in Sources */,
 				A13BEE801C9695C200C7E65A /* NetworkServer.cpp in Sources */,
@@ -572,16 +602,19 @@
 				A1A4344D1C7060430015F838 /* HardSectoredDisk.cpp in Sources */,
 				A13BEE651C96955A00C7E65A /* CPNetDevice.cpp in Sources */,
 				A1A434471C7060430015F838 /* h19.cpp in Sources */,
+				A192FCE51CE00A7800B4E8D5 /* MemoryDecoder.cpp in Sources */,
 				A1A434621C7060430015F838 /* Z47Controller.cpp in Sources */,
 				A1A4343A1C7060430015F838 /* Console.cpp in Sources */,
 				A1A434561C7060430015F838 /* ParallelPortConnection.cpp in Sources */,
 				A1A434601C7060430015F838 /* Track.cpp in Sources */,
+				A192FCDF1CDFC27400B4E8D5 /* H88MemoryLayout.cpp in Sources */,
 				A13BEE7B1C9695B700C7E65A /* MMS77318MemoryDecoder.cpp in Sources */,
 				A1A4343D1C7060430015F838 /* disasm.cpp in Sources */,
 				A13C989A1C7A3839000CF03B /* StdioProxyConsole.cpp in Sources */,
 				A13C98881C7A3805000CF03B /* GenericDiskDrive.cpp in Sources */,
 				A1A434421C7060430015F838 /* FloppyDisk.cpp in Sources */,
 				A1A434461C7060430015F838 /* h17.cpp in Sources */,
+				A1CA80A81CD73EAE004A11B7 /* TD0FloppyDisk.cpp in Sources */,
 				A1A4344A1C7060430015F838 /* h89-io.cpp in Sources */,
 				A13BEE701C96959600C7E65A /* H89MemoryDecoder.cpp in Sources */,
 				A1A434451C7060430015F838 /* h-17-4.cpp in Sources */,
@@ -595,6 +628,7 @@
 				A15861A91CB8DCE500D3382D /* WD179xUserIf.cpp in Sources */,
 				A1A4345D1C7060430015F838 /* SoftSectoredDisk.cpp in Sources */,
 				A1A4345C1C7060430015F838 /* SignalHandler.cpp in Sources */,
+				A192FCD91CDFB68100B4E8D5 /* Memory8K.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/VirtualH89/Src/AddressBus.cpp
+++ b/VirtualH89/Src/AddressBus.cpp
@@ -10,7 +10,8 @@
 #include "MemoryDecoder.h"
 #include "InterruptController.h"
 
-AddressBus::AddressBus(InterruptController* ic): ic_m(ic), mem(NULL)
+AddressBus::AddressBus(InterruptController* ic): ic_m(ic),
+                                                 mem_m(nullptr)
 {
     debugss(ssAddressBus, INFO, "\n");
 }
@@ -32,40 +33,31 @@ AddressBus::readByte(WORD addr,
         return ic_m->readDataBus();
     }
 
-    // Could do this entirely inside MemoryLayout, but this way we have
-    // more options for direct access to all memory.
-    int bnk = mem->getCurrentBank();
+    debugss(ssAddressBus, ALL, "addr(%d)\n", addr);
 
-    debugss(ssAddressBus, ALL, "addr(%d), bank(%d)\n", addr, bnk);
-
-    return mem->readByte(bnk, addr);
+    return mem_m->readByte(addr);
 }
 
 void
 AddressBus::writeByte(WORD addr,
                       BYTE val)
 {
+    debugss(ssAddressBus, ALL, "addr(%d) = %d\n", addr, val);
 
-    // Could do this entirel inside MemoryLayout, but this way we have
-    // more options for direct access to all memory.
-    int bnk = mem->getCurrentBank();
-
-    debugss(ssAddressBus, ALL, "addr(%d) = %d, bank(%d)\n", addr, val, bnk);
-
-    mem->writeByte(bnk, addr, val);
+    mem_m->writeByte(addr, val);
 }
 
 void
 AddressBus::installMemory(MemoryDecoder* memory)
 {
-    mem = memory;
+    mem_m = memory;
 }
 
 void
 AddressBus::reset()
 {
-    if (mem != NULL)
+    if (mem_m != nullptr)
     {
-        mem->reset();
+        mem_m->reset();
     }
 }

--- a/VirtualH89/Src/AddressBus.h
+++ b/VirtualH89/Src/AddressBus.h
@@ -12,11 +12,9 @@
 
 #include "h89Types.h"
 
-const int addressLine_c  = 16;
-const int memorySize_c   = 1L << addressLine_c;
-const int pageSizeBits_c = 10;
-const int pageSize_c     = 1L << pageSizeBits_c;
-const int numOfPages_c   = memorySize_c / pageSize_c;
+
+/// \todo make AddressBus a base class and this functionality in an H89AddressBus
+/// class
 
 class MemoryDecoder;
 class InterruptController;
@@ -30,7 +28,7 @@ class InterruptController;
 class AddressBus
 {
   private:
-    MemoryDecoder*       mem;
+    MemoryDecoder*       mem_m;
     InterruptController* ic_m;
 
   public:

--- a/VirtualH89/Src/GenericDiskDrive.cpp
+++ b/VirtualH89/Src/GenericDiskDrive.cpp
@@ -10,8 +10,6 @@
 #include "GenericDiskDrive.h"
 
 
-#include "WallClock.h"
-#include "logger.h"
 
 GenericDiskDrive::GenericDiskDrive()
 {

--- a/VirtualH89/Src/GenericDiskDrive.h
+++ b/VirtualH89/Src/GenericDiskDrive.h
@@ -12,8 +12,6 @@
 
 #include <string>
 
-#include "h89Types.h"
-
 class GenericFloppyDisk;
 
 ///

--- a/VirtualH89/Src/GenericFloppyDrive.cpp
+++ b/VirtualH89/Src/GenericFloppyDrive.cpp
@@ -11,7 +11,6 @@
 
 #include "WallClock.h"
 #include "logger.h"
-#include "FloppyDisk.h"
 #include "GenericFloppyFormat.h"
 #include "GenericFloppyDisk.h"
 
@@ -174,7 +173,7 @@ GenericFloppyDrive::readData(bool dd,
     {
         // TODO determine why CP/M didn't handle fallback properly.
         debugss(ssGenericFloppyDrive, WARNING, "DD mismatch(%d)\n", dd);
-        //    return GenericFloppyFormat::ERROR;
+        return GenericFloppyFormat::ERROR;
     }
 
     if (track_m != track || headSel_m != side)
@@ -292,9 +291,15 @@ BYTE
 GenericFloppyDrive::getMaxSectors(BYTE side,
                                   BYTE track)
 {
+    if (track_m != track || headSel_m != side)
+    {
+        debugss(ssGenericFloppyDrive, WARNING, "mismatch trk %d:%d sid %d:%d\n", track_m, track,
+                headSel_m, side);
+    }
+
     if (disk_m)
     {
-        return disk_m->getMaxSectors(side, track);
+        return disk_m->getMaxSectors(headSel_m, track_m);
     }
 
 

--- a/VirtualH89/Src/GenericFloppyDrive.h
+++ b/VirtualH89/Src/GenericFloppyDrive.h
@@ -12,6 +12,8 @@
 
 #include "GenericDiskDrive.h"
 
+#include "h89Types.h"
+
 class GenericFloppyDisk;
 
 ///

--- a/VirtualH89/Src/GenericSASIDrive.h
+++ b/VirtualH89/Src/GenericSASIDrive.h
@@ -12,6 +12,8 @@
 
 #include "GenericDiskDrive.h"
 
+#include "h89Types.h"
+
 class GenericFloppyDisk;
 
 ///

--- a/VirtualH89/Src/H37InterruptController.cpp
+++ b/VirtualH89/Src/H37InterruptController.cpp
@@ -29,8 +29,8 @@ H37InterruptController::~H37InterruptController()
 void
 H37InterruptController::setINTLine()
 {
-//    debugss(ssH37InterruptController, INFO, "intLevel: %d intrqRaised_m: %d drqRaised: %d\n",
-//            intLevel_m, intrqRaised_m, drqRaised_m);
+    // debugss(ssH37InterruptController, INFO, "intLevel: %d intrqRaised_m: %d drqRaised: %d\n",
+    //        intLevel_m, intrqRaised_m, drqRaised_m);
 
     if ((!interruptsBlocked_m && intLevel_m != 0) || intrqRaised_m || drqRaised_m)
     {
@@ -64,6 +64,7 @@ H37InterruptController::readDataBus()
     else if (drqRaised_m)
     {
         // EI
+        debugss(ssH37InterruptController, ALL, "drq set\n");
         opCode = 0xfb;
     }
     else if (!interruptsBlocked_m)
@@ -73,7 +74,7 @@ H37InterruptController::readDataBus()
     else
     {
         debugss(ssH37InterruptController, ERROR, "readData bus, but nothing to provide\n");
-
+        opCode = InterruptController::readDataBus();
     }
 
     debugss(ssH37InterruptController, ALL, "opCode: %d\n", opCode);
@@ -85,10 +86,6 @@ H37InterruptController::setIntrq(bool raise)
 {
     debugss(ssH37InterruptController, VERBOSE, "Entering: %d\n", raise);
     intrqRaised_m = raise;
-/*    if (raise)
-    {
-        interruptsBlocked_m = false;
-    }*/
     setINTLine();
 }
 
@@ -104,7 +101,7 @@ void
 H37InterruptController::blockInterrupts(bool block)
 {
     debugss(ssH37InterruptController, INFO, "Entering: %d\n", block);
-    setINTLine();
 
     interruptsBlocked_m = block;
+    setINTLine();
 }

--- a/VirtualH89/Src/H88MemoryDecoder.cpp
+++ b/VirtualH89/Src/H88MemoryDecoder.cpp
@@ -7,28 +7,41 @@
 /// \author Douglas Miller
 ///
 #include "H88MemoryDecoder.h"
-#include "MemoryDecoder.h"
+
+
+#include "H88MemoryLayout.h"
 
 /// H88 48K Memory
-H88MemoryDecoder::H88MemoryDecoder(MemoryLayout* h89_0):
-    MemoryDecoder(1, 0) {
+H88MemoryDecoder::H88MemoryDecoder(MemoryLayout* h89_0): MemoryDecoder(2,
+                                                                       h89_gppOrg0Bit_c)
+{
     addLayout(0, h89_0);
+    MemoryLayout* h89_1 = new H88MemoryLayout(h89_0);
+
+    addLayout(1, h89_1);
 }
-H88MemoryDecoder::~H88MemoryDecoder(){
+
+H88MemoryDecoder::~H88MemoryDecoder()
+{
 }
 
 void
-H88MemoryDecoder::gppNewValue(BYTE gpo) {
-    // This never gets called.
-    curBank = 0;
+H88MemoryDecoder::gppNewValue(BYTE gpo)
+{
+    curBank_m = ((gpo & h89_gppOrg0Bit_c) ? 1 : 0);
 }
 
 void
-H88MemoryDecoder::reset() {
-    curBank = 0;
+H88MemoryDecoder::reset()
+{
+    curBank_m = 0;
 }
 
 void
-H88MemoryDecoder::addLayout(int ix, MemoryLayout* lo) {
-    banks[0] = lo;
+H88MemoryDecoder::addLayout(int ix, MemoryLayout* lo)
+{
+    if (ix >= 0 && ix < numBanks_m)
+    {
+        banks_m[ix] = lo;
+    }
 }

--- a/VirtualH89/Src/H88MemoryDecoder.h
+++ b/VirtualH89/Src/H88MemoryDecoder.h
@@ -10,7 +10,7 @@
 #define H88MEMORYDECODER_H_
 
 #include "MemoryDecoder.h"
-#include "MemoryLayout.h"
+
 
 class H88MemoryDecoder: public MemoryDecoder
 {
@@ -22,6 +22,8 @@ class H88MemoryDecoder: public MemoryDecoder
     virtual void reset();
   private:
     virtual void gppNewValue(BYTE gpo);
+
+    static const BYTE h89_gppOrg0Bit_c = 0b00100000;
 };
 
 #endif // H88MEMORYDECODER_H_

--- a/VirtualH89/Src/H88MemoryLayout.cpp
+++ b/VirtualH89/Src/H88MemoryLayout.cpp
@@ -1,0 +1,34 @@
+///
+///  \file H88MemoryLayout.cpp
+///
+///  \author Mark Garlanger
+///  \date   May 8, 2016
+///
+
+#include "H88MemoryLayout.h"
+
+#include "RAMemory8K.h"
+
+
+H88MemoryLayout::H88MemoryLayout(shared_ptr<Memory8K> hdos): MemoryLayout()
+{
+    // ROM at 0x0000
+    addPage(hdos);
+    // in non-Org 0 mode the 48k of RAM is at 8K -> 56K
+    for (int x = 1; x < 7; ++x)
+    {
+        addPage(make_shared<RAMemory8K>(pageToAddress(x)));
+    }
+}
+
+H88MemoryLayout::H88MemoryLayout(MemoryLayout* nonOrg0Layout): MemoryLayout()
+{
+    // Org-0 has the memory from 48K to 56K mapped to address 0.
+    for (int x = 1; x < 6; ++x)
+    {
+        addPage(nonOrg0Layout->getPage(x));
+    }
+
+    //
+    addPageAt(nonOrg0Layout->getPage(6), 0x0000);
+}

--- a/VirtualH89/Src/H88MemoryLayout.h
+++ b/VirtualH89/Src/H88MemoryLayout.h
@@ -10,20 +10,14 @@
 #define H88MEMORYLAYOUT_H_
 
 #include "MemoryLayout.h"
-#include "Memory8K.h"
-#include "RAMemory8K.h"
+
+class Memory8K;
 
 class H88MemoryLayout: public MemoryLayout
 {
   public:
-    H88MemoryLayout(Memory8K* hdos): MemoryLayout() {
-        addPage(hdos);
-        int x;
-        for (x = 1; x < 7; ++x)
-        {
-            addPage(new RAMemory8K(x << 13));
-        }
-    }
+    H88MemoryLayout(shared_ptr<Memory8K> hdos);
+    H88MemoryLayout(MemoryLayout* nonOrg0Layout);
 };
 
 #endif // H88MEMORYLAYOUT_H_

--- a/VirtualH89/Src/H89.cpp
+++ b/VirtualH89/Src/H89.cpp
@@ -41,7 +41,6 @@
 #include "logger.h"
 #include "propertyutil.h"
 
-#include <stdlib.h>
 #include <vector>
 
 H89::H89(): Computer()
@@ -50,44 +49,9 @@ H89::H89(): Computer()
 }
 
 void
-H89::buildSystem(Console* console)
+H89::buildSystem(Console* console, PropertyUtil::PropertyMapT props)
 {
-    PropertyUtil::PropertyMapT props;
-
-    // TODO: allow specification of config file via cmdline args.
-    std::string                cfg;
-    char*                      env = getenv("V89_CONFIG");
-
     this->console = console;
-
-    if (env)
-    {
-        // If file-not-found, we still might create it later...
-        cfg = env;
-
-        try
-        {
-            PropertyUtil::read(cfg.c_str(), props);
-        }
-
-        catch (std::exception& e)
-        {
-        }
-    }
-    else
-    {
-        cfg  = getenv("HOME");
-        cfg += "/.v89rc";
-
-        try
-        {
-            PropertyUtil::read(cfg.c_str(), props);
-        }
-
-        catch (std::exception& e)
-        {
-        }
-    }
 
     std::string s; // for general property queries.
 
@@ -177,14 +141,14 @@ H89::buildSystem(Console* console)
         cpu->enableFast();
     }
 
-    HDOS = new HDOSMemory8K();
+    HDOS = make_shared<HDOSMemory8K>();
     HDOS->installROM(monitorROM);
     HDOS->installROM(h17ROM);
     HDOS->enableRAM(0x1400, 1024);
 
     MemoryDecoder* memDecoder;
     // All sytems have the core 48K + ROM.
-    // \TODO Allow for 16K/32K  - also support ORG-0 with less than 64k
+    // \TODO Allow for 16K/32K  - also make support ORG-0 configurable.
     MemoryLayout*  h89_0 = new H88MemoryLayout(HDOS); // creates 48K RAM at 0x2000...
 
 
@@ -195,15 +159,7 @@ H89::buildSystem(Console* console)
     driveUnitH2 = nullptr;
 
     // Z37
-    h37         = nullptr;
-    driveUnitS0 = nullptr;
-    driveUnitS1 = nullptr;
-    driveUnitS2 = nullptr;
-    driveUnitS3 = nullptr;
-    soft0       = nullptr;
-    soft1       = nullptr;
-    soft2       = nullptr;
-    soft3       = nullptr;
+    Z_89_37*   h37 = nullptr;
 
     // Z47
     z47If       = nullptr;
@@ -214,11 +170,11 @@ H89::buildSystem(Console* console)
     eight0      = nullptr;
     eight1      = nullptr;
 
-    MMS77316*                m316 = NULL;
-    MMS77320*                m320 = NULL;
+    MMS77316*                m316 = nullptr;
+    MMS77320*                m320 = nullptr;
     CPNetDevice*             cpn  = CPNetDevice::install_CPNetDevice(props);
 
-    if (cpn != NULL)
+    if (cpn != nullptr)
     {
         h89io->addDevice(cpn);
     }

--- a/VirtualH89/Src/H89.h
+++ b/VirtualH89/Src/H89.h
@@ -22,6 +22,9 @@
 #include <pthread.h>
 
 #include "computer.h"
+#include "propertyutil.h"
+
+#include <memory>
 
 // Forward declare classes to avoid a tangled mess of includes.
 
@@ -35,8 +38,6 @@ class H89_IO;
 class NMIPort;
 class GeneralPurposePort;
 class INS8250;
-class H17;
-class Z_89_37;
 class Z47Interface;
 class Z47Controller;
 class DiskDrive;
@@ -46,6 +47,8 @@ class FloppyDisk;
 class ParallelLink;
 class HDOSMemory8K;
 
+using namespace std;
+
 ///
 /// \brief Virtual Heathkit %H89 Computer
 ///
@@ -54,57 +57,46 @@ class HDOSMemory8K;
 class H89: public Computer
 {
   private:
-    AddressBus*          ab;
-    InterruptController* interruptController;
-    H89Timer*            timer;
+    AddressBus*              ab;
+    InterruptController*     interruptController;
+    H89Timer*                timer;
 
-    H89_IO*              h89io;
+    H89_IO*                  h89io;
 
-    GeneralPurposePort*  gpp;
+    GeneralPurposePort*      gpp;
 
-    NMIPort*             nmi1;
-    NMIPort*             nmi2;
+    NMIPort*                 nmi1;
+    NMIPort*                 nmi2;
 
-    INS8250*             consolePort;
-    INS8250*             lpPort;
-    INS8250*             modemPort;
-    INS8250*             auxPort;
+    INS8250*                 consolePort;
+    INS8250*                 lpPort;
+    INS8250*                 modemPort;
+    INS8250*                 auxPort;
 
-    Console*             console;
-    Z_89_37*             h37;
-    Z47Interface*        z47If;
-    Z47Controller*       z47Cntrl;
-    ParallelLink*        z47Link;
+    Console*                 console;
+    Z47Interface*            z47If;
+    Z47Controller*           z47Cntrl;
+    ParallelLink*            z47Link;
 
-    DiskDrive*           driveUnitH0;
-    DiskDrive*           driveUnitH1;
-    DiskDrive*           driveUnitH2;
+    DiskDrive*               driveUnitH0;
+    DiskDrive*               driveUnitH1;
+    DiskDrive*               driveUnitH2;
 
-    DiskDrive*           driveUnitS0;
-    DiskDrive*           driveUnitS1;
-    DiskDrive*           driveUnitS2;
-    DiskDrive*           driveUnitS3;
+    DiskDrive*               driveUnitE0;
+    DiskDrive*               driveUnitE1;
 
-    DiskDrive*           driveUnitE0;
-    DiskDrive*           driveUnitE1;
+    FloppyDisk*              hard0;
+    FloppyDisk*              hard1;
+    FloppyDisk*              hard2;
 
-    FloppyDisk*          hard0;
-    FloppyDisk*          hard1;
-    FloppyDisk*          hard2;
+    FloppyDisk*              eight0;
+    FloppyDisk*              eight1;
 
-    FloppyDisk*          soft0;
-    FloppyDisk*          soft1;
-    FloppyDisk*          soft2;
-    FloppyDisk*          soft3;
+    CPU*                     cpu;
 
-    FloppyDisk*          eight0;
-    FloppyDisk*          eight1;
-
-    CPU*                 cpu;
-
-    ROM*                 monitorROM;
-    ROM*                 h17ROM;
-    HDOSMemory8K*        HDOS;
+    ROM*                     monitorROM;
+    ROM*                     h17ROM;
+    shared_ptr<HDOSMemory8K> HDOS;
 
     /// Port Addresses
 
@@ -125,6 +117,7 @@ class H89: public Computer
     /// Addresses for the serial ports (NOTE addresses are in OCTAL)
     static const BYTE          Serial_Console_c           = 0350; // (0xe8)
     static const BYTE          Serial_Console_Interrupt_c = 3;
+
     static const BYTE          Serial_AuxPort_c           = 0320; // (0xD0)
     static const BYTE          Serial_ModemPort_c         = 0330; // (0xD8)
     static const BYTE          Serial_LpPort_c            = 0340; // (0xE0)
@@ -152,7 +145,7 @@ class H89: public Computer
   public:
     H89();
     virtual ~H89();
-    void buildSystem(Console* console);
+    void buildSystem(Console* console, PropertyUtil::PropertyMapT props);
 
     virtual void reset();
     virtual BYTE run();

--- a/VirtualH89/Src/H89MemoryDecoder.cpp
+++ b/VirtualH89/Src/H89MemoryDecoder.cpp
@@ -7,33 +7,38 @@
 /// \author Douglas Miller
 ///
 #include "H89MemoryDecoder.h"
-#include "MemoryDecoder.h"
+
 #include "Z64KMemoryLayout.h"
 
 /// H89 64K Memory
-H89MemoryDecoder::H89MemoryDecoder(MemoryLayout* h89_0):
-    MemoryDecoder(2, h89_gppOrg0Bit_c) {
-    MemoryLayout* h89_1 = new Z64KMemoryLayout(h89_0);
+H89MemoryDecoder::H89MemoryDecoder(MemoryLayout* h89_0): MemoryDecoder(2,
+                                                                       h89_gppOrg0Bit_c)
+{
     addLayout(0, h89_0);
+    MemoryLayout* h89_1 = new Z64KMemoryLayout(h89_0);
     addLayout(1, h89_1);
 }
-H89MemoryDecoder::~H89MemoryDecoder(){
+H89MemoryDecoder::~H89MemoryDecoder()
+{
 }
 
 void
-H89MemoryDecoder::gppNewValue(BYTE gpo) {
-    curBank = ((gpo & h89_gppOrg0Bit_c) ? 1 : 0);
+H89MemoryDecoder::gppNewValue(BYTE gpo)
+{
+    curBank_m = ((gpo & h89_gppOrg0Bit_c) ? 1 : 0);
 }
 
 void
-H89MemoryDecoder::reset() {
-    curBank = 0;
+H89MemoryDecoder::reset()
+{
+    curBank_m = 0;
 }
 
 void
-H89MemoryDecoder::addLayout(int ix, MemoryLayout* lo) {
-    if (ix >= 0 && ix < numBnks)
+H89MemoryDecoder::addLayout(int ix, MemoryLayout* lo)
+{
+    if (ix >= 0 && ix < numBanks_m)
     {
-        banks[ix] = lo;
+        banks_m[ix] = lo;
     }
 }

--- a/VirtualH89/Src/H89MemoryDecoder.h
+++ b/VirtualH89/Src/H89MemoryDecoder.h
@@ -10,7 +10,7 @@
 #define H89MEMORYDECODER_H_
 
 #include "MemoryDecoder.h"
-#include "MemoryLayout.h"
+
 
 class H89MemoryDecoder: public MemoryDecoder
 {

--- a/VirtualH89/Src/HDOSMemory8K.cpp
+++ b/VirtualH89/Src/HDOSMemory8K.cpp
@@ -1,0 +1,86 @@
+///
+/// \file HDOSMemory8K.cpp
+///
+///
+///  \author  Mark Garlanger
+///  \date    May 8, 2016
+
+#include "HDOSMemory8K.h"
+
+#include "ROM.h"
+
+HDOSMemory8K::HDOSMemory8K(): RAMemory8K(0x0000),
+                              maskRO(0),
+                              maskInstalled(0),
+                              RAM(nullptr)
+{
+}
+
+void
+HDOSMemory8K::overlayRAM(Memory8K* ram)
+{
+    RAM = ram;
+}
+
+void
+HDOSMemory8K::enableRAM(WORD base, WORD len)
+{
+    WORD adr = base & 0x1fff;
+    if (adr + len > sizeof(mem))
+    {
+        // error? or just trim?
+        len = sizeof(mem) - adr;
+    }
+    int a = (adr >> 10) & 0x07;
+    int n = a + (((len + 0x03ff) >> 10) & 0x07);
+    // TODO: find more-elegant way
+    for (; a < n; ++a)
+    {
+        maskInstalled |= (1 << a);
+    }
+}
+
+void
+HDOSMemory8K::writeProtect(WORD adr, WORD len)
+{
+    int a = (adr >> 10) & 0x07;
+    int n = a + (((len + 0x03ff) >> 10) & 0x07);
+    // TODO: find more-elegant way
+    for (; a < n && a < 8; ++a)
+    {
+        maskRO |= (1 << a);
+    }
+}
+
+void
+HDOSMemory8K::writeEnable(WORD adr, WORD len)
+{
+    int a = (adr >> 10) & 0x07;
+    int n = a + (((len + 0x03ff) >> 10) & 0x07);
+    // TODO: find more-elegant way
+    for (; a < n && a < 8; ++a)
+    {
+        maskRO &= ~(1 << a);
+    }
+}
+
+void
+HDOSMemory8K::installROM(ROM* rom)
+{
+    WORD adr = rom->getBase() & 0x1fff;
+    int  len = rom->getSize();
+    if (adr + len > sizeof(mem))
+    {
+        // error? or just trim?
+        len = sizeof(mem) - adr;
+    }
+    memcpy(&mem[adr], rom->getImage(), len);
+    int a = (adr >> 10) & 0x07;
+    int n = a + (((len + 0x03ff) >> 10) & 0x07);
+    // TODO: find more-elegant way
+    for (; a < n; ++a)
+    {
+        maskRO        |= (1 << a);
+        maskInstalled |= (1 << a);
+    }
+}

--- a/VirtualH89/Src/HDOSMemory8K.h
+++ b/VirtualH89/Src/HDOSMemory8K.h
@@ -11,75 +11,23 @@
 #define HDOSMEMORY8K_H_
 
 #include "RAMemory8K.h"
-#include "Memory8K.h"
+
+
+class ROM;
 
 class HDOSMemory8K: public RAMemory8K
 {
   public:
-    HDOSMemory8K():
-        RAMemory8K(0x0000),
-        maskRO(0),
-        maskInstalled(0),
-        RAM(NULL)
-    {
-    }
-    void overlayRAM(Memory8K* ram) {
-        RAM = ram;
-    }
-    void enableRAM(WORD base, WORD len) {
-        WORD adr = base & 0x1fff;
-        if (adr + len > sizeof(mem))
-        {
-            // error? or just trim?
-            len = sizeof(mem) - adr;
-        }
-        int a = (adr >> 10) & 0x07;
-        int n = a + (((len + 0x03ff) >> 10) & 0x07);
-        // TODO: find more-elegant way
-        for (; a < n; ++a)
-        {
-            maskInstalled |= (1 << a);
-        }
-    }
-    void writeProtect(WORD adr, WORD len) {
-        int a = (adr >> 10) & 0x07;
-        int n = a + (((len + 0x03ff) >> 10) & 0x07);
-        // TODO: find more-elegant way
-        for (; a < n && a < 8; ++a)
-        {
-            maskRO |= (1 << a);
-        }
-    }
-    void writeEnable(WORD adr, WORD len) {
-        int a = (adr >> 10) & 0x07;
-        int n = a + (((len + 0x03ff) >> 10) & 0x07);
-        // TODO: find more-elegant way
-        for (; a < n && a < 8; ++a)
-        {
-            maskRO &= ~(1 << a);
-        }
-    }
-    void installROM(ROM* rom) {
-        WORD adr = rom->getBase() & 0x1fff;
-        int  len = rom->getSize();
-        if (adr + len > sizeof(mem))
-        {
-            // error? or just trim?
-            len = sizeof(mem) - adr;
-        }
-        memcpy(&mem[adr], rom->getImage(), len);
-        int a = (adr >> 10) & 0x07;
-        int n = a + (((len + 0x03ff) >> 10) & 0x07);
-        // TODO: find more-elegant way
-        for (; a < n; ++a)
-        {
-            maskRO        |= (1 << a);
-            maskInstalled |= (1 << a);
-        }
-    }
+    HDOSMemory8K();
+    void overlayRAM(Memory8K* ram);
+    void enableRAM(WORD base, WORD len);
+    void writeProtect(WORD adr, WORD len);
+    void writeEnable(WORD adr, WORD len);
+    void installROM(ROM* rom);
+
     void writeByte(WORD adr, BYTE val) {
         // "write under ROM" accesses both DRAM and H17-RAM
-        if (RAM != NULL)
+        if (RAM != nullptr)
         {
             RAM->writeByte(adr, val);
         }
@@ -93,6 +41,7 @@ class HDOSMemory8K: public RAMemory8K
         }
         RAMemory8K::writeByte(adr, val);
     }
+
   private:
     unsigned int maskRO;
     unsigned int maskInstalled;

--- a/VirtualH89/Src/HardSectoredDisk.cpp
+++ b/VirtualH89/Src/HardSectoredDisk.cpp
@@ -106,7 +106,7 @@ HardSectoredDisk::readData(BYTE          side,
 
     if (maxTrack_m != tracks_m)
     {
-        if ((maxTrack_m == 80) && (tracks_m = 40))
+        if ((maxTrack_m == 80) && (tracks_m == 40))
         {
             debugss(ssFloppyDisk, INFO, "max - 80 trk_m - 40 | track - %d  newTrack - %d\n",
                     track, track / 2);
@@ -158,7 +158,7 @@ HardSectoredDisk::writeData(BYTE          side,
 
     if (maxTrack_m != tracks_m)
     {
-        if ((maxTrack_m == 80) && (tracks_m = 40))
+        if ((maxTrack_m == 80) && (tracks_m == 40))
         {
             debugss(ssFloppyDisk, INFO, "max - 80 trk_m - 40\n");
             track /= 2;

--- a/VirtualH89/Src/HardSectoredDisk.h
+++ b/VirtualH89/Src/HardSectoredDisk.h
@@ -15,7 +15,7 @@ class DiskData;
 
 /// \class HardSectoredDisk
 ///
-/// \brief Virtual hard-sectored disk, currently just supports SS/40-track disks.
+/// \brief Virtual hard-sectored disk
 ///
 /// This class implements a virtual hard-sectored disk. It models the entire track
 /// such as the headers and gaps, not only the data portion.

--- a/VirtualH89/Src/IMDFloppyDisk.cpp
+++ b/VirtualH89/Src/IMDFloppyDisk.cpp
@@ -13,10 +13,7 @@
 #include "GenericFloppyFormat.h"
 #include "logger.h"
 
-
-#include <iostream>
 #include <fstream>
-#include <cstdlib>
 
 
 GenericFloppyDisk*
@@ -67,7 +64,7 @@ IMDFloppyDisk::IMDFloppyDisk(std::vector<std::string> argv): GenericFloppyDisk()
         ready_m = false;
         debugss(ssFloppyDisk, ERROR, "Read of file %s failed\n", name);
     }
-    
+
     free(name);
 }
 
@@ -234,6 +231,8 @@ IMDFloppyDisk::readIMD(const char* name)
         debugss(ssFloppyDisk, ALL, "Head:    %d\n", head);
 
         Track* trk = new Track(head, cyl);
+        trk->setDataRate(dataRate);
+        trk->setDensity(density);
 
         numSec        = buf[pos++];
         debugss(ssFloppyDisk, ALL, "Num Sectors:    %d\n", numSec);

--- a/VirtualH89/Src/MMS77318MemoryDecoder.h
+++ b/VirtualH89/Src/MMS77318MemoryDecoder.h
@@ -30,7 +30,7 @@ class MMS77318MemoryDecoder: public MemoryDecoder
                                              h89_gppBnkSelBit2_c);
     static const BYTE h89_gppUnlockBits_c = 0b00001100;
     int               lockState;
-    static BYTE       lockSeq[];
+    static const BYTE lockSeq[];
 };
 
 #endif // MMS77318MEMORYDECODER_H_

--- a/VirtualH89/Src/Memory64K.h
+++ b/VirtualH89/Src/Memory64K.h
@@ -9,27 +9,27 @@
 #ifndef MEMORY64K_H_
 #define MEMORY64K_H_
 
-#include "Memory8K.h"
-#include "RAMemory8K.h"
+#include "h89Types.h"
+
+#include <memory>
+
+class Memory8K;
+
+using namespace std;
 
 class Memory64K
 {
   public:
-    Memory64K() {
-        int x;
+    Memory64K();
 
-        // for 64K all base addresses are defined
-        for (x = 0; x < 8; ++x)
-        {
-            mem64k[x] = new RAMemory8K(x << 13);
-        }
+    shared_ptr<Memory8K> getPage(BYTE page)
+    {
+        // \todo - error if out of range
+        return mem64k[page & 0x7];
     }
-    Memory8K* getPage(WORD adr) {
-        int a = ((adr >> 13) & 0x07);
-        return mem64k[a];
-    }
+
   private:
-    Memory8K* mem64k[8];
+    shared_ptr<Memory8K> mem64k[8];
 };
 
 #endif // MEMORY64K_H_

--- a/VirtualH89/Src/Memory64k.cpp
+++ b/VirtualH89/Src/Memory64k.cpp
@@ -1,0 +1,19 @@
+///
+///  \file Memory64k.cpp
+///
+///  \author  Mark Garlanger
+///  \date    May 8, 2016
+///
+
+#include "Memory64K.h"
+
+#include "RAMemory8K.h"
+
+Memory64K::Memory64K() {
+
+    // for 64K all base addresses are defined
+    for (int x = 0; x < 8; ++x)
+    {
+        mem64k[x] = make_shared<RAMemory8K>(x << 13);
+    }
+}

--- a/VirtualH89/Src/Memory8K.cpp
+++ b/VirtualH89/Src/Memory8K.cpp
@@ -1,0 +1,17 @@
+///
+///  \file Memory8K.cpp
+///
+///  \author  Mark Garlanger
+///  \date    May 8, 2016
+///
+
+#include "Memory8K.h"
+
+#include <string.h>
+
+
+Memory8K::Memory8K(WORD base): base_m(base)
+{
+
+    memset(mem, 0, sizeof(mem));
+}

--- a/VirtualH89/Src/Memory8K.h
+++ b/VirtualH89/Src/Memory8K.h
@@ -11,24 +11,22 @@
 
 #include "h89Types.h"
 
-#include <string.h>
 
 class Memory8K
 {
   public:
-    Memory8K(WORD ba) {
-        base = ba;
-        memset(mem, 0, sizeof(mem));
-    }
+    Memory8K(WORD base);
+
     inline WORD getBase() {
-        return base;
+        return base_m;
     }
     inline BYTE readByte(WORD adr) {
         return mem[adr & 0x1fff];
     }
     virtual void writeByte(WORD adr, BYTE val) = 0;
+
   protected:
-    WORD base;
+    WORD base_m;
     BYTE mem[8 * 1024];
 };
 

--- a/VirtualH89/Src/MemoryDecoder.cpp
+++ b/VirtualH89/Src/MemoryDecoder.cpp
@@ -1,0 +1,24 @@
+///
+///  \file MemoryDecoder.cpp
+///
+///  \author Mark Garlanger
+///  \date   May 8, 2016
+///
+
+#include "MemoryDecoder.h"
+
+
+
+MemoryDecoder::MemoryDecoder(int numBanks, BYTE gppBits): GppListener(gppBits),
+                                                          curBank_m(0),
+                                                          bankMask_m(numBanks - 1),
+                                                          numBanks_m(numBanks)
+{
+    banks_m = new MemoryLayout*[numBanks];
+    GppListener::addListener(this);
+}
+
+MemoryDecoder::~MemoryDecoder()
+{
+
+}

--- a/VirtualH89/Src/MemoryDecoder.h
+++ b/VirtualH89/Src/MemoryDecoder.h
@@ -13,43 +13,57 @@
 #include "MemoryLayout.h"
 #include "GppListener.h"
 
+#include "Memory8K.h"
 
 class MemoryDecoder: public GppListener
 {
   public:
-    MemoryDecoder(int numBanks, BYTE gppBits): GppListener(gppBits) {
-        numBnks = numBanks;
-        bnkMask = numBanks - 1; // assumes power of 2
-        banks   = new MemoryLayout*[numBanks];
-        curBank = 0;
-        GppListener::addListener(this);
-    }
-    virtual ~MemoryDecoder() {
-    }
+    MemoryDecoder(int numBanks, BYTE gppBits);
+    virtual ~MemoryDecoder();
+
     virtual void reset()                             = 0;
     virtual void addLayout(int ix, MemoryLayout* lo) = 0;
-    inline MemoryLayout* getLayout(int ix) {
-        return banks[ix & bnkMask];
-    }
-    inline int numLayouts() {
-        return numBnks;
-    }
-    inline int getCurrentBank() {
-        return curBank;
+
+    inline MemoryLayout* getLayout(int ix)
+    {
+        return banks_m[ix & bankMask_m];
     }
 
-    inline BYTE readByte(int ix, WORD adr) {
-        return getLayout(ix)->getPage(adr)->readByte(adr);
+    inline int numLayouts()
+    {
+        return numBanks_m;
     }
+
+    inline int getCurrentBank()
+    {
+        return curBank_m;
+    }
+
+    inline BYTE readByte(int ix, WORD adr)
+    {
+        return getLayout(ix)->getPageByAddress(adr)->readByte(adr);
+    }
+
     inline void writeByte(int ix, WORD adr, BYTE val)
     {
-        getLayout(ix)->getPage(adr)->writeByte(adr, val);
+        getLayout(ix)->getPageByAddress(adr)->writeByte(adr, val);
     }
+
+    inline BYTE readByte(WORD address)
+    {
+        return getLayout(curBank_m)->getPageByAddress(address)->readByte(address);
+    }
+    inline void writeByte(WORD address, BYTE val)
+    {
+        getLayout(curBank_m)->getPageByAddress(address)->writeByte(address, val);
+    }
+
+
   protected:
-    BYTE           curBank;
-    int            bnkMask;
-    int            numBnks;
-    MemoryLayout** banks;
+    BYTE           curBank_m;
+    int            bankMask_m;
+    int            numBanks_m;
+    MemoryLayout** banks_m;
 };
 
 #endif // MEMORYDECODER_H_

--- a/VirtualH89/Src/MemoryLayout.cpp
+++ b/VirtualH89/Src/MemoryLayout.cpp
@@ -1,0 +1,44 @@
+///
+///  \file MemoryLayout.cpp
+///
+///  \author Mark Garlanger
+///  \date   May 8, 2016
+///
+
+#include "MemoryLayout.h"
+
+#include "Memory64K.h"
+#include "NilMemory8K.h"
+
+
+
+MemoryLayout::MemoryLayout()
+{
+    for (int x = 0; x < 8; ++x)
+    {
+        memPage_m[x] = make_shared<NilMemory8K>(pageToAddress(x));
+    }
+}
+
+void
+MemoryLayout::addPage(shared_ptr<Memory8K> mem)
+{
+    // error if not NULL?
+    memPage_m[addressToPage(mem->getBase())] = mem;
+}
+
+void
+MemoryLayout::addPageAt(shared_ptr<Memory8K> mem, WORD address)
+{
+    // error if not NULL?
+    memPage_m[addressToPage(address)] = mem;
+}
+
+void
+MemoryLayout::addPage(Memory64K* mem64)
+{
+    for (int x = 0; x < 8; ++x)
+    {
+        addPage(mem64->getPage(x));
+    }
+}

--- a/VirtualH89/Src/Sector.cpp
+++ b/VirtualH89/Src/Sector.cpp
@@ -11,8 +11,8 @@
 #include "logger.h"
 
 #include <iostream>
-
-Sector::Sector(): headNum_m(0),
+/*
+   Sector::Sector(): headNum_m(0),
                   trackNum_m(0),
                   sectorNum_m(0),
                   deletedDataAddressMark_m(false),
@@ -20,9 +20,9 @@ Sector::Sector(): headNum_m(0),
                   valid_m(false),
                   data_m(0),
                   sectorLength_m(0)
-{
+   {
 
-}
+   }*/
 
 Sector::Sector(BYTE  headNum,
                BYTE  trackNum,
@@ -83,14 +83,14 @@ Sector::~Sector()
 
     valid_m = false;
 }
-
-void
-Sector::initialize(BYTE  headNum,
+/*
+   void
+   Sector::initialize(BYTE  headNum,
                    BYTE  trackNum,
                    BYTE  sectorNum,
                    WORD  sectorLength,
                    BYTE* data)
-{
+   {
     if (valid_m)
     {
         // Error condition, shouldn't initialize an already valid object
@@ -99,6 +99,8 @@ Sector::initialize(BYTE  headNum,
                 headNum, trackNum, sectorNum);
 
     }
+    debugss(ssFloppyDisk, INFO, "Sector initializing - h: %d t: %d s: %d, len: %d\n",
+            headNum, trackNum, sectorNum, sectorLength);
 
     headNum_m      = headNum;
     trackNum_m     = trackNum;
@@ -119,8 +121,8 @@ Sector::initialize(BYTE  headNum,
     {
         valid_m = false;
     }
-}
-
+   }
+ */
 void
 Sector::setDeletedDataAddressMark(bool val)
 {
@@ -133,12 +135,22 @@ Sector::setReadError(bool val)
     readError_m = val;
 }
 
+bool
+Sector::getDeletedDataAddressMark()
+{
+    return deletedDataAddressMark_m;
+}
+bool
+Sector::getReadError()
+{
+    return readError_m;
+}
+
 void
 Sector::dump()
 {
-    printf("Sector dump - Side: %d Track: %d Sector: %d\n", headNum_m,
-           trackNum_m,
-           sectorNum_m);
+    debugss(ssFloppyDisk, INFO, "Sector dump - Side: %d Track: %d Sector: %d\n",
+            headNum_m, trackNum_m, sectorNum_m);
 
     char printable[17];
 
@@ -148,13 +160,13 @@ Sector::dump()
     {
         if ((i % 16) == 0)
         {
-            printf("     0x%04x: ", i);
+            debugss(ssFloppyDisk, INFO, "     0x%04x: ", i);
         }
         else
         {
             if ((i % 8) == 0)
             {
-                printf(" ");
+                debugss_nts(ssFloppyDisk, INFO, " ");
             }
         }
 
@@ -162,11 +174,11 @@ Sector::dump()
         printable[i % 16] = (isprint(data_m[i])) ? data_m[i] : '.';
 
         // print hex value
-        printf("%02x", data_m[i]);
+        debugss_nts(ssFloppyDisk, INFO, "%02x", data_m[i]);
 
         if (((i + 1) % 16) == 0)
         {
-            printf("  %s\n", printable);
+            debugss_nts(ssFloppyDisk, INFO, "  %s\n", printable);
         }
     }
 }

--- a/VirtualH89/Src/Sector.h
+++ b/VirtualH89/Src/Sector.h
@@ -22,9 +22,10 @@ class Sector
     bool  valid_m;
     BYTE* data_m;
     WORD  sectorLength_m;
+    Sector();
 
   public:
-    Sector();
+    //
     Sector(BYTE  headNum,
            BYTE  trackNum,
            BYTE  sectorNum,
@@ -36,17 +37,13 @@ class Sector
            BYTE sectorNum,
            WORD sectorLength,
            BYTE data = 0xe5);
-
-    void initialize(BYTE  headNum,
-                    BYTE  trackNum,
-                    BYTE  sectorNum,
-                    WORD  sectorLength,
-                    BYTE* data);
-
     virtual ~Sector();
 
     void setDeletedDataAddressMark(bool val);
     void setReadError(bool val);
+
+    bool getDeletedDataAddressMark();
+    bool getReadError();
 
     BYTE getSectorNum();
     WORD getSectorLength();

--- a/VirtualH89/Src/SectorFloppyImage.cpp
+++ b/VirtualH89/Src/SectorFloppyImage.cpp
@@ -200,6 +200,7 @@ SectorFloppyImage::SectorFloppyImage(GenericDiskDrive*        drive,
         debugss(ssSectorFloppyImage, ERROR, "file is not SectorFloppyImage (%d,%d) - %s\n", x,
                 errno,
                 name);
+        free((void*) name);
         return;
     }
 

--- a/VirtualH89/Src/SerialPortDevice.cpp
+++ b/VirtualH89/Src/SerialPortDevice.cpp
@@ -7,7 +7,8 @@
 #include "SerialPortDevice.h"
 
 #include "INS8250.h"
-#include <cstdio>
+#include "logger.h"
+
 
 SerialPortDevice::SerialPortDevice(): port_m(0)
 {
@@ -40,6 +41,7 @@ SerialPortDevice::sendData(BYTE data)
         return true;
     }
 
-    printf("port_m is NULL\n");
+    debugss(ssSerial, WARNING, "port_m is NULL\n");
+
     return false;
 }

--- a/VirtualH89/Src/SoftSectoredDisk.cpp
+++ b/VirtualH89/Src/SoftSectoredDisk.cpp
@@ -591,13 +591,13 @@ SoftSectoredDisk::determineDiskFormat(const char*      name,
 void
 SoftSectoredDisk::dump()
 {
-    printf("SoftSectored - dump\n");
+    debugss(ssFloppyDisk, INFO, "SoftSectored - dump\n");
 
     for (int head = 0; head < numHeads_m; head++)
     {
         for (int track = 0; track < numTracks_m; track++)
         {
-            printf("  Head: %d  Track: %d\n", head, track);
+            debugss(ssFloppyDisk, INFO, "  Head: %d  Track: %d\n", head, track);
 
             tracks_m[head][track]->dump();
         }

--- a/VirtualH89/Src/TD0FloppyDisk.cpp
+++ b/VirtualH89/Src/TD0FloppyDisk.cpp
@@ -1,0 +1,953 @@
+///
+///  \file TD0FloppyDisk.cpp
+///
+///  \author Mark Garlanger
+///  \date   May 2, 2016
+///
+
+#include "TD0FloppyDisk.h"
+
+#include "Track.h"
+#include "Sector.h"
+
+#include "GenericFloppyFormat.h"
+#include "logger.h"
+
+#include <fstream>
+
+
+unsigned char TD0FloppyDisk::d_code[256] = {
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+    0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02,
+    0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03,
+    0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05,
+    0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07,
+    0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x09, 0x09, 0x09, 0x09, 0x09, 0x09, 0x09, 0x09,
+    0x0A, 0x0A, 0x0A, 0x0A, 0x0A, 0x0A, 0x0A, 0x0A, 0x0B, 0x0B, 0x0B, 0x0B, 0x0B, 0x0B, 0x0B, 0x0B,
+    0x0C, 0x0C, 0x0C, 0x0C, 0x0D, 0x0D, 0x0D, 0x0D, 0x0E, 0x0E, 0x0E, 0x0E, 0x0F, 0x0F, 0x0F, 0x0F,
+    0x10, 0x10, 0x10, 0x10, 0x11, 0x11, 0x11, 0x11, 0x12, 0x12, 0x12, 0x12, 0x13, 0x13, 0x13, 0x13,
+    0x14, 0x14, 0x14, 0x14, 0x15, 0x15, 0x15, 0x15, 0x16, 0x16, 0x16, 0x16, 0x17, 0x17, 0x17, 0x17,
+    0x18, 0x18, 0x19, 0x19, 0x1A, 0x1A, 0x1B, 0x1B, 0x1C, 0x1C, 0x1D, 0x1D, 0x1E, 0x1E, 0x1F, 0x1F,
+    0x20, 0x20, 0x21, 0x21, 0x22, 0x22, 0x23, 0x23, 0x24, 0x24, 0x25, 0x25, 0x26, 0x26, 0x27, 0x27,
+    0x28, 0x28, 0x29, 0x29, 0x2A, 0x2A, 0x2B, 0x2B, 0x2C, 0x2C, 0x2D, 0x2D, 0x2E, 0x2E, 0x2F, 0x2F,
+    0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3A, 0x3B, 0x3C, 0x3D, 0x3E, 0x3F
+};
+
+unsigned char TD0FloppyDisk::d_len[] = {
+    2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 6, 6, 6, 7
+};
+
+
+//
+// Initialize the decompressor trees and state variables
+//
+void
+TD0FloppyDisk::init_decompress()
+{
+    unsigned i, j;
+
+    for (i = j = 0; i < N_CHAR; ++i)
+    {
+        // Walk up
+        freq[i]           = 1;
+        son[i]            = i + TSIZE;
+        parent[i + TSIZE] = i;
+    }
+
+    while (i <= ROOT)
+    {
+        // Back down
+        freq[i]   = freq[j] + freq[j + 1];
+        son[i]    = j;
+        parent[j] = parent[j + 1] = i++;
+        j        += 2;
+    }
+
+    memset(ring_buff, ' ', sizeof ring_buff);
+    freq[TSIZE]  = 0xFFFF;
+    parent[ROOT] = Bitbuff = Bits = 0;
+    GBr          = SBSIZE - LASIZE;
+}
+
+//
+// Increment frequency tree entry for a given code
+//
+void
+TD0FloppyDisk::update(int c)
+{
+    unsigned i, j, k, f, l;
+
+    if (freq[ROOT] == MAX_FREQ)
+    {
+        // Tree is full - rebuild
+        // Halve cumulative freq for leaf nodes
+        for (i = j = 0; i < TSIZE; ++i)
+        {
+            if (son[i] >= TSIZE)
+            {
+                freq[j] = (freq[i] + 1) / 2;
+                son[j]  = son[i];
+                ++j;
+            }
+        }
+
+        // make a tree - first connect children nodes
+        for (i = 0, j = N_CHAR; j < TSIZE; i += 2, ++j)
+        {
+            k = i + 1;
+            f = freq[j] = freq[i] + freq[k];
+            for (k = j - 1; f < freq[k]; --k)
+            {
+                ;
+            }
+            ++k;
+            l       = (j - k) * sizeof(freq[0]);
+
+            memmove(&freq[k + 1], &freq[k], l);
+            freq[k] = f;
+            memmove(&son[k + 1], &son[k], l);
+            son[k]  = i;
+        }
+
+        // Connect parent nodes
+        for (i = 0; i < TSIZE; ++i)
+        {
+            if ((k = son[i]) >= TSIZE)
+            {
+                parent[k] = i;
+            }
+            else
+            {
+                parent[k] = parent[k + 1] = i;
+            }
+        }
+    }
+
+    c = parent[c + TSIZE];
+
+    do
+    {
+        k = ++freq[c];
+        // Swap nodes if necessary to maintain frequency ordering
+        if (k > freq[l = c + 1])
+        {
+            while (k > freq[++l])
+            {
+                ;
+            }
+            freq[c]            = freq[--l];
+            freq[l]            = k;
+            parent[i = son[c]] = l;
+            if (i < TSIZE)
+            {
+                parent[i + 1] = l;
+            }
+            parent[j = son[l]] = c;
+            son[l]             = i;
+            if (j < TSIZE)
+            {
+                parent[j + 1] = c;
+            }
+            son[c] = j;
+            c      = l;
+        }
+    }
+    while ((c = parent[c]) != 0); // Repeat up to root
+}
+
+//
+// Get a byte from the input file and flag Eof at end
+//
+unsigned
+TD0FloppyDisk::GetChar()
+{
+    unsigned c;
+    if (pos < size)
+    {
+        c = buf[pos++];
+    }
+    else
+    {
+        c   = 0;
+        Eof = true;
+    }
+
+    return c;
+}
+
+//
+// Get a single bit from the input stream
+//
+unsigned
+TD0FloppyDisk::GetBit()
+{
+    unsigned t;
+    if (!Bits--)
+    {
+        Bitbuff |= GetChar() << 8;
+        Bits     = 7;
+    }
+
+    t         = (Bitbuff >> 15) & 0x01;
+    Bitbuff <<= 1;
+    return t;
+}
+
+//
+// Get a byte from the input stream - NOT bit-aligned
+//
+unsigned
+TD0FloppyDisk::GetByte()
+{
+    unsigned t;
+    if (Bits < 8)
+    {
+        Bitbuff |= GetChar() << (8 - Bits);
+    }
+    else
+    {
+        Bits -= 8;
+    }
+
+    t         = Bitbuff >> 8;
+    Bitbuff <<= 8;
+    return (t & 0xff);
+}
+
+//
+// Decode a character value from table
+//
+unsigned
+TD0FloppyDisk::DecodeChar()
+{
+    unsigned c;
+
+    // search the tree from the root to leaves.
+    // choose node #(son[]) if input bit == 0
+    // choose node #(son[]+1) if input bit == 1
+    c = ROOT;
+    while ((c = son[c]) < TSIZE)
+    {
+        c += GetBit();
+    }
+
+    update(c -= TSIZE);
+    return c;
+}
+
+//
+// Decode a compressed string index from the table
+//
+unsigned
+TD0FloppyDisk::DecodePosition()
+{
+    unsigned i, j, c;
+
+    // Decode upper 6 bits from given table
+    i = GetByte();
+    c = d_code[i] << 6;
+
+    // input lower 6 bits directly
+    j = d_len[i >> 4];
+    while (--j)
+    {
+        i = (i << 1) | GetBit();
+    }
+
+    return (i & 0x3F) | c;
+}
+
+//
+// Get a byte from the input file - decompress if required
+//
+// This implements a state machine to perform the LZSS decompression
+// allowing us to decompress the file "on the fly", without having to
+// have it all in memory.
+//
+int
+TD0FloppyDisk::getbyte()
+{
+    unsigned c;
+
+    --GBcheck;
+    if (!advanceCompression_m)
+    {
+        // No compression
+        return GetChar();
+    }
+
+    for (;; )
+    {
+        // Decompressor state machine
+        if (Eof)
+        {
+            // End of file has been flagged
+            return -1;
+        }
+        if (!GBstate)
+        {
+            // Not in the middle of a string
+            c = DecodeChar();
+            if (c < 256)
+            {
+                // Direct data extraction
+                ring_buff[GBr++] = c;
+                GBr             &= (SBSIZE - 1);
+                return c;
+            }
+            GBstate = true; // Begin extracting a compressed string
+            GBi     = (GBr - DecodePosition() - 1) & (SBSIZE - 1);
+            GBj     = c - 255 + THRESHOLD;
+            GBk     = 0;
+        }
+        if (GBk < GBj)
+        {
+            // Extract a compressed string
+            ring_buff[GBr++] = c = ring_buff[(GBk++ + GBi) & (SBSIZE - 1)];
+            GBr             &= (SBSIZE - 1);
+            return c;
+        }
+        GBstate = false; // Reset to non-string state
+    }
+}
+
+//
+// Get a word from the input file via getbyte (for compression)
+//
+unsigned
+TD0FloppyDisk::getword()
+{
+    unsigned w = getbyte();
+    w |= (getbyte() << 8);
+    return w;
+}
+
+
+
+GenericFloppyDisk*
+TD0FloppyDisk::getDiskette(std::vector<std::string> argv)
+{
+    GenericFloppyDisk* gd = new TD0FloppyDisk(argv);
+
+    if (!gd->isReady())
+    {
+        delete gd;
+        gd = nullptr;
+    }
+
+    return gd;
+}
+
+
+TD0FloppyDisk::TD0FloppyDisk(std::vector<std::string> argv): GenericFloppyDisk(),
+                                                             imageName_m(nullptr),
+                                                             curSector_m(nullptr),
+                                                             dataPos_m(0),
+                                                             sectorLength_m(0),
+                                                             secLenCode_m(0),
+                                                             hypoTrack_m(false),
+                                                             hyperTrack_m(false),
+                                                             advanceCompression_m(false),
+                                                             ready_m(true)
+{
+    if (argv.size() < 1)
+    {
+        debugss(ssFloppyDisk, WARNING, "no file specified\n");
+        return;
+    }
+
+    char* name = strdup(argv[0].c_str());
+    debugss(ssFloppyDisk, INFO, "reading: %s\n", name);
+
+    for (int x = 1; x < argv.size(); ++x)
+    {
+        if (argv[x].compare("rw") == 0)
+        {
+            writeProtect_m = false;
+        }
+    }
+
+
+    if (!readTD0(name))
+    {
+        ready_m = false;
+        debugss(ssFloppyDisk, ERROR, "Read of file %s failed\n", name);
+    }
+
+    free(name);
+}
+
+TD0FloppyDisk::~TD0FloppyDisk()
+{
+
+}
+
+bool
+TD0FloppyDisk::findSector(int side,
+                          int track,
+                          int sector)
+{
+
+    if (!tracks_m[side][track])
+    {
+        return false;
+    }
+    curSector_m = tracks_m[side][track]->findSector(sector);
+    if (!curSector_m)
+    {
+        return false;
+    }
+    if (curSector_m->getHeadNum() != side || curSector_m->getTrackNum() != track)
+    {
+        curSector_m = nullptr;
+        return false;
+    }
+
+    sectorLength_m = curSector_m->getSectorLength();
+    // TODO handle if the L options is set to '0'.
+    switch (sectorLength_m)
+    {
+        case 128:
+            secLenCode_m = 0;
+            break;
+
+        case 256:
+            secLenCode_m = 1;
+            break;
+
+        case 512:
+            secLenCode_m = 2;
+            break;
+
+        case 1024:
+            secLenCode_m = 3;
+            break;
+
+        default:
+            debugss(ssFloppyDisk, ERROR, "bad sector size: %d\n", sectorLength_m);
+            curSector_m = nullptr;
+            return false;
+    }
+
+    return true;
+}
+
+
+bool
+TD0FloppyDisk::readTD0(const char* name)
+{
+    std::ifstream   file;
+
+    Track::Density  density;
+    Track::DataRate dataRate;
+
+    debugss(ssFloppyDisk, INFO, "file: %s\n", name);
+
+    file.open(name, std::ios::binary);
+    file.seekg(0, std::ios::end);
+    size = file.tellg();
+    file.seekg(0, std::ios::beg);
+
+    buf  = new BYTE[size];
+    file.read((char*) buf, size);
+    file.close();
+
+    if ((buf[0] == 'T') && (buf[1] == 'D'))
+    {
+        debugss(ssFloppyDisk, INFO, "TD0 file with Normal Compression\n");
+        advanceCompression_m = false;
+    }
+    else if ((buf[0] == 't') && (buf[1] == 'd'))
+    {
+        debugss(ssFloppyDisk, INFO, "TD0 file with Advanced Compression\n");
+        advanceCompression_m = true;
+        init_decompress();
+
+        delete [] buf;
+
+        return (false);
+    }
+    else
+    {
+        debugss(ssFloppyDisk, ERROR, "Not a TD0 file: 0x%02x 0x%02x\n", buf[0], buf[1]);
+
+        delete [] buf;
+
+        return (false);
+    }
+
+
+    debugss(ssFloppyDisk, INFO, "Sequence: %d\n", buf[2]);
+    debugss(ssFloppyDisk, INFO, "Check Sequence: %d\n", buf[3]);
+    debugss(ssFloppyDisk, INFO, "Teledisk Version %d.%d\n", buf[4] & 0xf0 >> 4, buf[4] & 0x0f);
+    debugss(ssFloppyDisk, INFO, "Data Rate: %d\n", buf[5]);
+    switch (buf[5] & 0x3)
+    {
+        case 0:
+            dataRate = Track::dr_250kbps;
+            break;
+
+        case 1:
+            dataRate = Track::dr_300kbps;
+            break;
+
+        case 2:
+            dataRate = Track::dr_500kbps;
+            break;
+
+        default:
+            debugss(ssFloppyDisk, ERROR, " Unknown(%d)", buf[5]);
+            dataRate = Track::dr_Unknown;
+            break;
+    }
+    if (buf[5] & 0x80)
+    {
+        density         = Track::singleDensity;
+        doubleDensity_m = false;
+    }
+    else
+    {
+        density         = Track::doubleDensity;
+        doubleDensity_m = true;
+    }
+    debugss(ssFloppyDisk, INFO, "Density: %d\n", density);
+
+
+    debugss(ssFloppyDisk, INFO, "Drive Type:  %d\n", buf[6]);
+    debugss(ssFloppyDisk, INFO, "DOS Allocation flag: %s\n", ((buf[8] != 0) ? "True" : "False"));
+    debugss(ssFloppyDisk, INFO, "Sides: %s\n", ((buf[9] == 1) ? "1" : "2"));
+    debugss(ssFloppyDisk, INFO, "CRC Check: 0x%02x%02x\n", buf[10], buf[11]);
+
+    pos = 12;
+
+    if (buf[7] & 0x80)
+    {
+        unsigned char a, b, c;
+
+        debugss(ssFloppyDisk, INFO, "Comment: \n");
+        a = getbyte();
+        b = getbyte();
+        debugss(ssFloppyDisk, INFO, "CRC Check: 0x%02x%02x\n", a, b);
+
+        unsigned commentLen = getword();
+        debugss(ssFloppyDisk, INFO, "Data Length: %d\n", commentLen);
+        a = getbyte();
+        b = getbyte();
+        c = getbyte();
+        debugss(ssFloppyDisk, INFO, "Year: %d/%d/%d\n", 1900 + a, b, c);
+        a = getbyte();
+        b = getbyte();
+        c = getbyte();
+        debugss(ssFloppyDisk, INFO, "Time: %d:%02d:%02d\n", a, b, c);
+
+        // debugss(ssFloppyDisk, INFO, "     Comment: ");
+
+        for (int i = 0; i < commentLen; i++)
+        {
+            // \todo ignore comment for now, but need to store it, so that when
+            // image is written back to disk, it can be written too.
+            // a = getbyte();
+
+            getbyte();
+        }
+
+    }
+
+    bool done = false;
+
+    // read track
+    do
+    {
+        int sectors  = getbyte();
+        int cylinder = getbyte();
+        int side     = getbyte();
+        density = (side & 0x80) ? Track::singleDensity : Track::doubleDensity;
+        side   &= 0x01;
+
+        int crc = getbyte();
+        debugss(ssFloppyDisk, INFO, "Track %d head: %d density: %d CRC: %d\n", cylinder,
+                side, density, crc);
+
+        if (sectors == 255)
+        {
+            done = true;
+        }
+        else
+        {
+
+            Track* trk = new Track(side, cylinder);
+            trk->setDensity(density);
+            trk->setDataRate(dataRate);
+
+            for (int sectorNum = 0; sectorNum < sectors; sectorNum++)
+            {
+                int secCyl  = getbyte();
+                int secHead = getbyte();
+                int secNum  = getbyte();
+                int secSize = 0;
+
+                int tmp     = getbyte();
+                if (tmp < 7)
+                {
+                    secSize = 128 << tmp;
+                }
+                else
+                {
+                    debugss(ssFloppyDisk, ERROR, "Unknown sector size: %d\n", tmp);
+                }
+
+                int secFlags = getbyte();
+                int secCRC   = getbyte();
+
+                debugss(ssFloppyDisk, INFO, "Sector %d data:\n", sectorNum);
+                debugss(ssFloppyDisk, INFO, "Cyl: %d\n", secCyl);
+                debugss(ssFloppyDisk, INFO, "Head: %d\n", secHead);
+                debugss(ssFloppyDisk, INFO, "Num: %d\n", secNum);
+                debugss(ssFloppyDisk, INFO, "Size: %d\n", secSize);
+                debugss(ssFloppyDisk, INFO, "Flags: 0x%02x", secFlags);
+                debugss(ssFloppyDisk, INFO, "CRC: 0x%02x", secCRC);
+
+                // make sure there is data
+                if ((secFlags & 0x30) == 0)
+                {
+                    unsigned      blockSize = getword();
+
+                    // apparently blockSize includes the encoding byte, take it off
+                    blockSize--;
+                    int           encoding = getbyte();
+
+                    unsigned char block[8096];
+                    int           blockPos;
+                    switch (encoding)
+                    {
+                        case 0: // Raw Data
+
+                            for (int count = 0; count < blockSize; count++)
+                            {
+                                block[count] = getbyte();
+                            }
+                            break;
+
+                        case 1: // Repeat 2 bytes
+
+                            blockPos = 0;
+                            do
+                            {
+                                int           runlength;
+                                unsigned char val[2];
+
+                                runlength = getword();
+
+                                val[0]    = getbyte();
+                                val[1]    = getbyte();
+
+                                for (int j = 0; j < runlength; j++)
+                                {
+                                    block[blockPos++] = val[0];
+                                    block[blockPos++] = val[1];
+                                }
+                            }
+                            while (blockPos < secSize);
+                            break;
+
+                        case 2: // Run Length Encoding
+
+                            blockPos = 0;
+                            do
+                            {
+                                int code;
+                                code = getbyte();
+
+                                if (code == 0)
+                                {
+                                    // run of raw bytes.
+                                    int length;
+
+                                    length = getbyte();
+                                    while (length--)
+                                    {
+                                        block[blockPos++] = getbyte();
+                                    }
+                                }
+                                else
+                                {
+                                    // run-length encoded.
+                                    // length of data that is repeating
+                                    int l      = code * 2;
+                                    // the number of time to repeat it
+                                    int repeat = getbyte();
+
+                                    // instead of copying data to a temp block and copy
+                                    // from there, read it into the actual block and
+                                    // read the repeated blocks from the previously
+                                    // written data.
+
+                                    // read in the data
+                                    for (int k = 0; k < l; k++)
+                                    {
+                                        block[blockPos++] = getbyte();
+                                    }
+
+                                    // Now just copy the data from the previous read.
+                                    for (int j = 1; j < repeat; j++)
+                                    {
+                                        for (int k = 0; k < l; k++)
+                                        {
+                                            // look back at the last read
+                                            block[blockPos] = block[blockPos - l];
+                                            blockPos++;
+                                        }
+                                    }
+                                }
+                            }
+                            while (blockPos < secSize);
+                            break;
+
+                        default:
+
+                            debugss(ssFloppyDisk, ERROR, "Unknown sector encoding %d\n", encoding);
+                            break;
+
+                    }
+                    // create sector
+                    Sector* sect = new Sector(secHead, secCyl, secNum, secSize, block);
+
+                    // set flags
+                    sect->setReadError((secFlags & 0x02) == 0x02);
+                    sect->setDeletedDataAddressMark((secFlags & 0x04) == 0x04);
+
+                    // add sector to track
+                    trk->addSector(sect);
+
+                }
+
+            }
+            // add track to disk
+            tracks_m[side].push_back(trk);
+
+        }
+    }
+    while (!done);
+
+    delete [] buf;
+
+    debugss(ssFloppyDisk, INFO, "Read successful.\n");
+
+    return true;
+}
+
+
+bool
+TD0FloppyDisk::readData(BYTE track,
+                        BYTE side,
+                        BYTE sector,
+                        int  inSector,
+                        int& data)
+{
+
+    if (inSector < 0)
+    {
+        if (sector == 0xfd)
+        {
+            data = GenericFloppyFormat::ID_AM;
+        }
+        else if (sector == 0xff)
+        {
+            data = GenericFloppyFormat::INDEX_AM;
+        }
+        else if (findSector(side, track, sector))
+        {
+            dataPos_m = 0;
+            data      = GenericFloppyFormat::DATA_AM;
+        }
+        else
+        {
+            data = GenericFloppyFormat::NO_DATA;
+        }
+
+        return true;
+    }
+
+    if (sector == 0xfd)
+    {
+        switch (inSector)
+        {
+            case 0:
+                data = track;
+                break;
+
+            case 1:
+                data = side;
+                break;
+
+            case 2:
+                data = 1; // anything will do? 'sector' is 0xfd...
+                break;
+
+            case 3:
+                data = secLenCode_m;
+                break;
+
+            case 4:
+                data = 0; // CRC 1
+                break;
+
+            case 5:
+                data = 0; // CRC 2
+                break;
+
+            default:
+                data = GenericFloppyFormat::CRC;
+                break;
+        }
+
+        return true;
+    }
+    else if (sector == 0xff)
+    {
+        if (inSector < sectorLength_m)
+        {
+            // TODO: implement this
+            data = 0;
+        }
+        else
+        {
+            data = GenericFloppyFormat::CRC;
+        }
+
+        return true;
+    }
+
+    if (dataPos_m < sectorLength_m)
+    {
+        if (curSector_m)
+        {
+            BYTE sectorData;
+            curSector_m->readData(dataPos_m++, sectorData);
+            data = sectorData;
+        }
+        else
+        {
+            debugss(ssFloppyDisk, ERROR, "curSector_m not set\n");
+        }
+    }
+    else
+    {
+        debugss(ssFloppyDisk, INFO, "data done %d %d %d\n", track, side, sector);
+        data = GenericFloppyFormat::CRC;
+    }
+
+    return true;
+}
+
+bool
+TD0FloppyDisk::writeData(BYTE track,
+                         BYTE side,
+                         BYTE sector,
+                         int  inSector,
+                         BYTE data,
+                         bool dataReady,
+                         int& result)
+{
+
+    if (checkWriteProtect())
+    {
+        debugss(ssSectorFloppyImage, ERROR, "write protect\n");
+        return false;
+    }
+
+    if (inSector < 0)
+    {
+        if (sector == 0xff || sector == 0xfe)
+        {
+            result = GenericFloppyFormat::ERROR;
+        }
+        else if (findSector(side, track, sector))
+        {
+            dataPos_m = 0;
+            result    = GenericFloppyFormat::DATA_AM;
+        }
+        else
+        {
+            result = GenericFloppyFormat::NO_DATA;
+        }
+        return true;
+    }
+
+    debugss(ssSectorFloppyImage, INFO, "pos=%d data=%02x\n", inSector, data);
+
+    if (dataPos_m < sectorLength_m)
+    {
+
+        if (!dataReady)
+        {
+            debugss(ssSectorFloppyImage, ERROR, "data not read pos=%d\n", inSector);
+            result = GenericFloppyFormat::NO_DATA;
+        }
+        else
+        {
+            if (curSector_m)
+            {
+                curSector_m->writeData(dataPos_m++, data);
+
+                result = data;
+            }
+            else
+            {
+                debugss(ssFloppyDisk, ERROR, "curSector_m not set\n");
+            }
+        }
+    }
+    else
+    {
+        debugss(ssSectorFloppyImage, INFO, "CRC pos=%d data=%02x\n", inSector, data);
+        result = GenericFloppyFormat::CRC;
+    }
+
+    return true;
+}
+
+BYTE
+TD0FloppyDisk::getMaxSectors(BYTE side,
+                             BYTE track)
+{
+    BYTE sectors = 0;
+
+    if (tracks_m[side][track])
+    {
+        sectors = tracks_m[side][track]->getMaxSectors();
+    }
+
+    return sectors;
+}
+bool
+TD0FloppyDisk::isReady()
+{
+    return ready_m;
+}
+
+void
+TD0FloppyDisk::eject(const char* name)
+{
+    // \todo implement
+
+}
+
+void
+TD0FloppyDisk::dump(void)
+{
+    // \todo implement
+}
+
+std::string
+TD0FloppyDisk::getMediaName()
+{
+    if (!imageName_m)
+    {
+        return "NONE";
+    }
+
+    return imageName_m;
+}

--- a/VirtualH89/Src/TD0FloppyDisk.h
+++ b/VirtualH89/Src/TD0FloppyDisk.h
@@ -1,0 +1,125 @@
+///
+///  \file TD0FloppyDisk.h
+///
+///  \author Mark Garlanger
+///  \date May 2, 2016
+///
+
+#ifndef TD0FLOPPYDISK_H_
+#define TD0FLOPPYDISK_H_
+
+#include "GenericFloppyDisk.h"
+
+#include <vector>
+
+class Track;
+class Sector;
+
+class TD0FloppyDisk: public GenericFloppyDisk
+{
+  public:
+    TD0FloppyDisk(std::vector<std::string> argv);
+    virtual ~TD0FloppyDisk();
+
+    virtual bool readData(BYTE track,
+                          BYTE side,
+                          BYTE sector,
+                          int  inSector,
+                          int& data);
+    virtual bool writeData(BYTE track,
+                           BYTE side,
+                           BYTE sector,
+                           int  inSector,
+                           BYTE data,
+                           bool dataReady,
+                           int& result);
+    virtual BYTE getMaxSectors(BYTE sides,
+                               BYTE track);
+    virtual bool isReady();
+    virtual void eject(const char* name);
+    virtual void dump(void);
+    virtual std::string getMediaName();
+    static GenericFloppyDisk* getDiskette(std::vector<std::string> argv);
+
+  private:
+    const char*               imageName_m;
+    static const unsigned int maxHeads_c = 2;
+
+    std::vector <Track*>      tracks_m[maxHeads_c];
+
+    Sector*                   curSector_m;
+    int                       dataPos_m;
+    int                       sectorLength_m;
+    BYTE                      secLenCode_m;
+    bool                      ready_m;
+
+    bool                      hypoTrack_m;  // ST media in DT drive
+    bool                      hyperTrack_m; // DT media in ST drive
+
+    // bool          interlaced_m;
+    // int           mediaLat_m;
+    // BYTE          secLenCode_m;
+    // int           gapLen_m;
+    // int           indexGapLen_m;
+    // unsigned long writePos_m;
+    // bool          trackWrite_m;
+    // int           dataPos_m;
+    // int           dataLen_m;
+
+    // bool checkHeader(BYTE* buf, int n);
+    // bool cacheSector(int side, int track, int sector);
+
+  protected:
+    bool readTD0(const char* name);
+    bool findSector(int side, int track, int sector);
+
+    // LZSS parameters
+    static const int     SBSIZE    = 4096; // Size of Ring buffer
+    static const int     LASIZE    = 60;   // Size of Look-ahead buffer
+    static const int     THRESHOLD = 2;    // Minimum match for compress
+
+    // Huffman coding parameters
+    static const int     N_CHAR    = (256 - THRESHOLD + LASIZE); // Character code (= 0..N_CHAR-1)
+    static const int     TSIZE     = (N_CHAR * 2 - 1);           // Size of table
+    static const int     ROOT      = (TSIZE - 1);                // Root position
+    static const int     MAX_FREQ  = 0x8000;                     // Update when cumulative frequency
+                                                                 // reaches this value
+
+    unsigned long int    pos       = 0;
+    BYTE*                buf;
+    size_t               size;
+
+    unsigned int         parent[TSIZE + N_CHAR];         // parent nodes (0..T-1) and leaf positions (rest)
+    unsigned int         son[TSIZE];                     // pointers to child nodes (son[], son[]+1)
+    unsigned int         freq[TSIZE + 1];                // frequency table
+
+    unsigned int         Bits, Bitbuff;                  // buffered bit count and left-aligned bit buffer
+    unsigned int         GBcheck;                        // Getbyte check down-counter
+    unsigned int         GBr;                            // Ring buffer position
+    unsigned int         GBi;                            // Decoder index
+    unsigned int         GBj;                            // Decoder index
+    unsigned int         GBk;                            // Decoder index
+
+    unsigned char        ring_buff[SBSIZE + LASIZE - 1]; // text buffer for match strings
+
+    bool                 GBstate;                        // Decoder state
+    bool                 Eof;                            // End-of-file indicator
+    bool                 advanceCompression_m;
+
+    static unsigned char d_code[256];
+    static unsigned char d_len[];
+
+    void init_decompress();
+    void update(int c);
+    unsigned GetChar();
+    unsigned GetBit();
+    unsigned GetByte();
+    unsigned DecodeChar();
+    unsigned DecodePosition();
+    int getbyte();
+    unsigned getword();
+
+};
+
+
+#endif //  TD0FLOPPYDISK_H_

--- a/VirtualH89/Src/Track.cpp
+++ b/VirtualH89/Src/Track.cpp
@@ -7,7 +7,6 @@
 ///
 
 #include "Track.h"
-
 #include "Sector.h"
 
 #include "logger.h"
@@ -40,12 +39,14 @@ Track::addSector(Sector* sector)
 void
 Track::dump()
 {
-    printf("Dumping track - head: %d track: %d\n", sideNum_m, trackNum_m);
+    debugss(ssFloppyDisk, INFO, "Dumping track - head: %d track: %d\n", sideNum_m,
+            trackNum_m);
 
-    for (int sect = 0; sect < sectors_m.size(); sect++)
+
+    for (Sector* sector : sectors_m)
     {
-        printf("  Sector: %d\n", sect);
-        sectors_m[sect]->dump();
+        debugss(ssFloppyDisk, INFO, "  Sector: %d\n", sector->getSectorNum());
+        sector->dump();
     }
 }
 
@@ -62,19 +63,19 @@ Track::setDataRate(DataRate datarate)
 }
 
 bool
-Track::readSectorData(BYTE  sector,
+Track::readSectorData(BYTE  sectorNum,
                       WORD  pos,
                       BYTE& data)
 {
-    debugss(ssFloppyDisk, INFO, "sector: %d pos: %d\n", sector, pos);
+    debugss(ssFloppyDisk, INFO, "sector: %d pos: %d\n", sectorNum, pos);
 
-    for (int i = 0; i < sectors_m.size(); i++)
+    for (Sector* sector : sectors_m)
     {
-        if (sectors_m[i]->getSectorNum() == sector)
+        if (sector->getSectorNum() == sectorNum)
         {
             debugss(ssFloppyDisk, ALL, "found\n");
 
-            return sectors_m[i]->readData(pos, data);
+            return sector->readData(pos, data);
         }
     }
 
@@ -85,15 +86,15 @@ Track::readSectorData(BYTE  sector,
 }
 
 Sector*
-Track::findSector(BYTE sector)
+Track::findSector(BYTE sectorNum)
 {
-    for (int i = 0; i < sectors_m.size(); i++)
+    for (Sector* sector : sectors_m)
     {
-        if (sectors_m[i]->getSectorNum() == sector)
+        if (sector->getSectorNum() == sectorNum)
         {
             debugss(ssFloppyDisk, INFO, "found\n");
 
-            return sectors_m[i];
+            return sector;
         }
     }
 
@@ -104,5 +105,6 @@ BYTE
 Track::getMaxSectors()
 {
     // todo see if this should look through and find the highest sector number from all sectors.
+    // that is properly the right thing to do.
     return sectors_m.size() & 0xff;
 }

--- a/VirtualH89/Src/Track.h
+++ b/VirtualH89/Src/Track.h
@@ -38,9 +38,8 @@ class Track
   private:
     BYTE                  sideNum_m;
     BYTE                  trackNum_m;
-    // BYTE   numSectors_m;
-    std::vector <Sector*> sectors_m;
 
+    std::vector <Sector*> sectors_m;
 
     Density               density_m;
     DataRate              dataRate_m;

--- a/VirtualH89/Src/WallClock.cpp
+++ b/VirtualH89/Src/WallClock.cpp
@@ -62,9 +62,9 @@ WallClock::addTicks(unsigned ticks)
 {
     ticks_m += ticks;
 
-    for (std::list<ClockUser*>::iterator it = users_m.begin(); it != users_m.end(); ++it)
+    for (ClockUser* clockUser : users_m)
     {
-        (*it)->notification(ticks);;
+        clockUser->notification(ticks);;
     }
 }
 

--- a/VirtualH89/Src/Z64KMemoryLayout.cpp
+++ b/VirtualH89/Src/Z64KMemoryLayout.cpp
@@ -1,0 +1,25 @@
+///
+///  \file Z64KMemoryLayout.cpp
+///
+///  \author Mark Garlanger
+///  \date   May 8, 2016
+///
+
+#include "Z64KMemoryLayout.h"
+
+#include "RAMemory8K.h"
+
+
+Z64KMemoryLayout::Z64KMemoryLayout(MemoryLayout* rom): MemoryLayout()
+{
+
+    shared_ptr<Memory8K> rd6_0 = make_shared<RAMemory8K>(0x0000);
+    shared_ptr<Memory8K> rd6_1 = make_shared<RAMemory8K>(0xe000);
+    rom->addPage(rd6_1);
+    addPage(rd6_0);
+    for (int x = 1; x < 7; ++x)
+    {
+        addPage(rom->getPage(x));
+    }
+    addPage(rd6_1);
+}

--- a/VirtualH89/Src/Z64KMemoryLayout.h
+++ b/VirtualH89/Src/Z64KMemoryLayout.h
@@ -10,23 +10,11 @@
 #define Z64KMEMORYLAYOUT_H_
 
 #include "MemoryLayout.h"
-#include "RAMemory8K.h"
 
 class Z64KMemoryLayout: public MemoryLayout
 {
   public:
-    Z64KMemoryLayout(MemoryLayout* rom): MemoryLayout() {
-        int       x;
-        Memory8K* rd6_0 = new RAMemory8K(0x0000);
-        Memory8K* rd6_1 = new RAMemory8K(0xe000);
-        rom->addPage(rd6_1);
-        addPage(rd6_0);
-        for (x = 1; x < 7; ++x)
-        {
-            addPage(rom->getPage(x << 13));
-        }
-        addPage(rd6_1);
-    }
+    Z64KMemoryLayout(MemoryLayout* rom);
 };
 
 #endif // Z64KMEMORYLAYOUT_H_

--- a/VirtualH89/Src/h19.h
+++ b/VirtualH89/Src/h19.h
@@ -27,7 +27,7 @@
 class H19: public Console // , public BaseThread
 {
   public:
-    H19();
+    H19(std::string sw401, std::string sw402);
     virtual ~H19();
 
     virtual void init();
@@ -79,6 +79,8 @@ class H19: public Console // , public BaseThread
     };
     InputMode    mode;
     bool         updated;
+    BYTE         sw401_m;
+    BYTE         sw402_m;
 
     // display modes
     bool         reverseVideo;
@@ -170,6 +172,19 @@ class H19: public Console // , public BaseThread
         return (PosX == (rows - 1));
     };
     virtual void bell(void);
+
+    const BYTE RefreshRate_c  = 0x80;
+    const BYTE KeypadMode_c   = 0x40;
+    const BYTE TerminalMode_c = 0x20;
+    const BYTE AutoCR_c       = 0x10;
+    const BYTE AutoLF_c       = 0x08;
+    const BYTE WrapEOL_c      = 0x04;
+    const BYTE KeyClick_c     = 0x02;
+    const BYTE BlockCursor    = 0x01;
+
+    void setSW401(BYTE sw401);
+    void setSW402(BYTE sw402);
+
 };
 
 #endif // H19_H_

--- a/VirtualH89/Src/h37.cpp
+++ b/VirtualH89/Src/h37.cpp
@@ -15,6 +15,7 @@
 #include "computer.h"
 
 #include "IMDFloppyDisk.h"
+#include "TD0FloppyDisk.h"
 
 
 
@@ -128,7 +129,8 @@ Z_89_37::install_H37(Computer*                   computer,
                     /*SoftSectoredDisk* disk = new SoftSectoredDisk(
                                                                   s.c_str(), SoftSectoredDisk::dif_RAW);
                        drive->insertDisk(disk);*/
-                    drive->insertDisk(IMDFloppyDisk::getDiskette(PropertyUtil::splitArgs(s)));
+                    // drive->insertDisk(IMDFloppyDisk::getDiskette(PropertyUtil::splitArgs(s)));
+                    drive->insertDisk(TD0FloppyDisk::getDiskette(PropertyUtil::splitArgs(s)));
                 }
 
             }

--- a/VirtualH89/Src/h37.h
+++ b/VirtualH89/Src/h37.h
@@ -159,46 +159,24 @@ class Z_89_37: public DiskController, WD179xUserIf
 
     unsigned long long  cycleCount_m;
 
-    void seekTo();
-    void step(void);
-
-
-    ///
-    /// C - Side Compare Flag
-    /// ===============================================
-    /// 0 - Disable side compare
-    /// 1 - Enable side compare
-    ///
-    static const BYTE cmdop_SideCheck_c = 0x02;
-
-
-    ///
-    /// S - Side Compare Flag
-    /// ===============================================
-    /// 0 - Compare for side 0
-    /// 1 - Compare for side 1
-    ///
-    static const BYTE cmdop_CompareSide_c       = 0x08;
-    static const BYTE cmdop_CompareSide_Shift_c = 3;
-
 
     /// Bits set in cmd_ControlPort_c - DK.CON
-    static const BYTE ctrl_EnableIntReq_c    = 0x01;
-    static const BYTE ctrl_EnableDrqInt_c    = 0x02;
-    static const BYTE ctrl_SetMFMRecording_c = 0x04;
-    static const BYTE ctrl_MotorsOn_c        = 0x08;
-    static const BYTE ctrl_Drive_0_c         = 0x10;
-    static const BYTE ctrl_Drive_1_c         = 0x20;
-    static const BYTE ctrl_Drive_2_c         = 0x40;
-    static const BYTE ctrl_Drive_3_c         = 0x80;
+    static const BYTE   ctrl_EnableIntReq_c    = 0x01;
+    static const BYTE   ctrl_EnableDrqInt_c    = 0x02;
+    static const BYTE   ctrl_SetMFMRecording_c = 0x04;
+    static const BYTE   ctrl_MotorsOn_c        = 0x08;
+    static const BYTE   ctrl_Drive_0_c         = 0x10;
+    static const BYTE   ctrl_Drive_1_c         = 0x20;
+    static const BYTE   ctrl_Drive_2_c         = 0x40;
+    static const BYTE   ctrl_Drive_3_c         = 0x80;
 
     /// Bits to set alternate registers on InterfaceControl_c - DK.INT
-    static const BYTE if_SelectCommandData_c = 0x00;
-    static const BYTE if_SelectSectorTrack_c = 0x01;
+    static const BYTE   if_SelectCommandData_c = 0x00;
+    static const BYTE   if_SelectSectorTrack_c = 0x01;
 
     /// Floppy disk related items
-    static const int  bytesPerTrack_c        = 6400;
-    static const int  clocksPerByte_c        = 64;
+    static const int    bytesPerTrack_c        = 6400;
+    static const int    clocksPerByte_c        = 64;
 };
 
 #endif // Z_89_37_H_

--- a/VirtualH89/Src/logger.cpp
+++ b/VirtualH89/Src/logger.cpp
@@ -9,7 +9,8 @@
 
 #define ANSI 0
 
-unsigned debugLevel[ssMax];
+unsigned     debugLevel[ssMax];
+extern FILE* log_out;
 
 
 logger::logger():  printToFile(false),
@@ -35,7 +36,7 @@ setDebugLevel()
     debugLevel[ssROM]                    = defaultLevel; // ROM accesses
     debugLevel[ssZ80]                    = defaultLevel; // Z80 CPU
     debugLevel[ssH37InterruptController] = INFO;         // Interrupt Controller
-    debugLevel[ssInterruptController]    = defaultLevel; // Interrupt Controller
+    debugLevel[ssInterruptController]    = INFO;         // Interrupt Controller
     debugLevel[ssAddressBus]             = defaultLevel; // Address Bus
     debugLevel[ssIO]                     = defaultLevel; // I/O ports
     debugLevel[ssH17]                    = defaultLevel; // H17 controller
@@ -74,10 +75,10 @@ setDebug(subSystems ss,
 }
 
 void
-__debugss(enum subSystems subsys, enum logLevel level, const char* functionName,
-          const char* fmt, ...)
+__debugss(enum logLevel level, const char* functionName, const char* fmt, ...)
 {
     va_list vl;
+
 #if ANSI
     int     __val = 0;
     if (level < ERROR)
@@ -102,17 +103,35 @@ __debugss(enum subSystems subsys, enum logLevel level, const char* functionName,
     }
     fprintf(log_out, "\x1b[37m");
 #endif
+
     WallClock::instance()->printTime(log_out);
+
 #if ANSI
     fprintf(log_out, "\x1b[36m%s: \x1b[%dm", functionName, __val);
 #else
     fprintf(log_out, "%s: ", functionName);
 #endif
+
     va_start(vl, fmt);
     vfprintf(log_out, fmt, vl);
     va_end(vl);
+
 #if ANSI
     fprintf(log_out, "\x1b[0m");
 #endif
+
     fflush(log_out);
+}
+
+
+void
+__debugss_nts(const char* fmt, ...)
+{
+    va_list vl;
+
+    va_start(vl, fmt);
+    vfprintf(log_out, fmt, vl);
+    va_end(vl);
+    fflush(log_out);
+
 }

--- a/VirtualH89/Src/logger.h
+++ b/VirtualH89/Src/logger.h
@@ -9,7 +9,6 @@
 
 #include <cstdio>
 
-//#include "WallClock.h"
 
 extern FILE* log_out;
 
@@ -30,9 +29,6 @@ class logger
     FILE* logFile;
 
 };
-
-#define DEBUG 1
-#define DEBUG_TO_FILE 1
 
 ///
 enum subSystems
@@ -101,22 +97,22 @@ enum logLevel
     ALL     = 100
 };
 
-extern void __debugss(enum subSystems, enum logLevel, const char* functionName, const char* fmt,
-                      ...);
+extern void __debugss(enum logLevel, const char* functionName, const char* fmt, ...);
+extern void __debugss_nts(const char* fmt, ...);
 
-#define debugss(subsys, level, args ...)                     \
-    if (level <= debugLevel[subsys])                         \
-    {                                                        \
-        __debugss(subsys, level, __PRETTY_FUNCTION__, args); \
+
+#define debugss(subsys, level, args ...)             \
+    if (level <= debugLevel[subsys])                 \
+    {                                                \
+        __debugss(level, __PRETTY_FUNCTION__, args); \
     }
 
 
-// nts - No TimeStamp
 #define debugss_nts(subsys, level, args ...) \
     {                                        \
         if (level <= debugLevel[subsys])     \
         {                                    \
-            fprintf(log_out, args);          \
+            __debugss_nts(args);             \
         }                                    \
     }
 

--- a/VirtualH89/Src/wd1797.h
+++ b/VirtualH89/Src/wd1797.h
@@ -313,20 +313,20 @@ class WD1797: public ClockUser
     /// stat_DataRequest_c    - 0x02;
     /// stat_Busy_c           - 0x01;
 
-    static const int sectorLengths[2][4];
-    static const int HeadSettleTimeInTicks_c = 100;
-    static const int InitialSectorPos_c      = -11;
-    static const int ErrorSectorPos_c        = -1;
+    static const int   sectorLengths[2][4];
+    static const int   HeadSettleTimeInTicks_c = 100;
+    static const int   InitialSectorPos_c      = -11;
+    static const int   ErrorSectorPos_c        = -1;
 
   private:
-    WD179xUserIf*    userIf_m;
+    WD179xUserIf*      userIf_m;
 
-
+    unsigned long long cycleCount_m;
 
     void transferData(int data);
     void updateReady(GenericFloppyDrive* drive);
-    bool checkAddr(BYTE addr[6]);
-    int  sectorLen(BYTE addr[6]);
+    bool               checkAddr(BYTE addr[6]);
+    int                sectorLen(BYTE addr[6]);
 
 };
 

--- a/VirtualH89/Src/z80.cpp
+++ b/VirtualH89/Src/z80.cpp
@@ -948,8 +948,6 @@ Z80::READnn(void)
 };
 
 
-#define COMMON_GET 1
-
 inline BYTE&
 Z80::getReg8(BYTE val)
 {
@@ -1656,7 +1654,14 @@ Z80::traceInstructions(void)
     {
         debugss(ssZ80, ERROR, "0x%04x(%03o.%03o) %04x %04x %04x %04x %04x : ",
                 PC, (PC >> 8) & 0xff, (PC & 0xff), AF, BC, DE, HL, SP);
-        disass(PC);
+        if (mode == cm_halt)
+        {
+            debugss_nts(ssZ80, ERROR, "Halted\n");
+        }
+        else
+        {
+            disass(PC);
+        }
 
     }
 }
@@ -2187,6 +2192,8 @@ Z80::op_ei(void)
     IFF2 = true;
 
     // Keep IFF1 false, it will be set to true after the next instruction by IFF0
+    // this ensures that the next instruction executes before servicing another
+    // interrupt.
     IFF0 = true;
 
 }
@@ -2615,7 +2622,7 @@ Z80::op_ld_ihl_n(void)
     // displacement is 3rd byte and value is 4th.
     // Functions with side-effects can be dangerous.
     WORD adr = getIndirectAddr();
-    BYTE n = READn();
+    BYTE n   = READn();
     writeMEM(adr, n);
 }
 

--- a/VirtualH89/Src/z80.h
+++ b/VirtualH89/Src/z80.h
@@ -14,7 +14,6 @@
 #define Z80_H_
 
 #include <csignal>
-#include <vector>
 #include <pthread.h>
 
 #include "cpu.h"


### PR DESCRIPTION
 Improved H37 Support
- no longer seems to have random hangs,
  - fix was to allow interrupts to be processed, even if H37 interrupt controller
    is blocking interrupts. Looked to be a small window where interrupts were allowed,
    but not handled until it was blocking again.
- properly handles disk density.
- known issue - booting CP/M 2.2.03 dist disk, causes a R/O disk error if default system
               is selected - but CP/M 2.2.04 works fine, need to invesigate if it an issue
               with the software, or an issue with the disk/disk image.
  Improved Memory Subsystem
- used shared_ptrs to fix several memory leaks
- shuffled the includes to clean up the include tree
- moved non-performance critical functions (setup/teardown) into newly created .cpp files.
- allowed CP/M to work with 48k systems (org-0)
  TD0 file support added.

Overall configuration
- moved the reading of the config file into main.
- added options to specify the terminal board dipswitches - SW401, SW402
