### PR TITLE
Fix remaining issues in H37 controller - this included:

### DIFF
--- a/VirtualH89/Src/GenericFloppyDisk.h
+++ b/VirtualH89/Src/GenericFloppyDisk.h
@@ -52,7 +52,9 @@ class GenericFloppyDisk
                            int  inSector,
                            BYTE data,
                            bool dataReady,
-                           int& result)    = 0;
+                           int& result) = 0;
+
+    virtual BYTE getRealTrackNumber(BYTE track);
     virtual BYTE getMaxSectors(BYTE side,
                                BYTE track) = 0;
 
@@ -93,7 +95,6 @@ class GenericFloppyDisk
 
     ///
 /*
-    const char*               imageName_m;
     static const unsigned int maxHeads_c = 2;
 
     std::vector <Track*>      tracks_m[maxHeads_c];

--- a/VirtualH89/Src/GenericFloppyDrive.h
+++ b/VirtualH89/Src/GenericFloppyDrive.h
@@ -14,6 +14,8 @@
 
 #include "h89Types.h"
 
+#include "ClockUser.h"
+
 /// \cond
 #include <memory>
 /// \endcond
@@ -26,7 +28,7 @@ class GenericFloppyDisk;
 /// Implements a virtual floppy disk drive. Supports 48/96 tpi 5.25",
 /// 48 tpi 8", either can be SS or DS. Note, the media determines density.
 ///
-class GenericFloppyDrive: public GenericDiskDrive
+class GenericFloppyDrive: public GenericDiskDrive, ClockUser
 {
   public:
     enum DriveType
@@ -46,7 +48,7 @@ class GenericFloppyDrive: public GenericDiskDrive
     bool readAddress(int& track,
                      int& sector,
                      int& side);
-
+    bool verifyTrackSector(BYTE track, BYTE sector);
     void step(bool direction);
     void selectSide(BYTE side);
 
@@ -73,6 +75,10 @@ class GenericFloppyDrive: public GenericDiskDrive
 
     void headLoad(bool load); // Ignored on 5.25" drives?
     void motor(bool on);      // Ignored on 8" drives
+    void getDriveStatus(bool& writeProtected,
+                        bool& headLoaded,
+                        bool& trackZero,
+                        bool& indexPulse);
     bool getIndexPulse()
     {
         return indexPulse_m;
@@ -90,6 +96,8 @@ class GenericFloppyDrive: public GenericDiskDrive
 
     std::string getMediaName();
 
+    void startTrackFormat(BYTE trackNum);
+
   private:
     unsigned int                       numTracks_m;
     unsigned int                       numHeads_m;
@@ -105,7 +113,8 @@ class GenericFloppyDrive: public GenericDiskDrive
     int                                headSel_m;
     int                                track_m;
     bool                               motor_m;
-    bool                               head_m;
+    bool                               headLoaded_m;
+    bool                               writeProtected_m;
 
     GenericFloppyDrive(unsigned int heads,
                        unsigned int tracks,

--- a/VirtualH89/Src/IMDFloppyDisk.cpp
+++ b/VirtualH89/Src/IMDFloppyDisk.cpp
@@ -40,8 +40,6 @@ IMDFloppyDisk::IMDFloppyDisk(vector<string> argv): GenericFloppyDisk(),
                                                    dataPos_m(0),
                                                    sectorLength_m(0),
                                                    secLenCode_m(0),
-                                                   hypoTrack_m(false),
-                                                   hyperTrack_m(false),
                                                    ready_m(true)
 {
     if (argv.size() < 1)
@@ -410,7 +408,19 @@ IMDFloppyDisk::readData(BYTE track,
         switch (inSector)
         {
             case 0:
-                data = track;
+                if (hypoTrack_m)
+                {
+                    data = track / 2;
+                }
+                else if (hyperTrack_m)
+                {
+                    data = track * 2;
+                }
+                else
+                {
+                    data = track;
+                }
+                break;
                 break;
 
             case 1:
@@ -548,7 +558,7 @@ BYTE
 IMDFloppyDisk::getMaxSectors(BYTE side,
                              BYTE track)
 {
-    if (!tracks_m[side][track])
+    if ((track > tracks_m[side].size()) || !tracks_m[side][track])
     {
         return 0;
     }

--- a/VirtualH89/Src/IMDFloppyDisk.h
+++ b/VirtualH89/Src/IMDFloppyDisk.h
@@ -57,9 +57,6 @@ class IMDFloppyDisk: public GenericFloppyDisk
     BYTE                                       secLenCode_m;
     bool                                       ready_m;
 
-    bool                                       hypoTrack_m;  // ST media in DT drive
-    bool                                       hyperTrack_m; // DT media in ST drive
-
     // bool          interlaced_m;
     // int           mediaLat_m;
     // BYTE          secLenCode_m;

--- a/VirtualH89/Src/SoftSectoredDisk.cpp
+++ b/VirtualH89/Src/SoftSectoredDisk.cpp
@@ -626,7 +626,8 @@ SoftSectoredDisk::readSectorData(BYTE  side,
 {
     debugss(ssFloppyDisk, ALL, "side: %d track: %d sector: %d pos: %d\n", side, track, sector, pos);
 
-    return tracks_m[side][track]->readSectorData(sector, pos, data);
+    // return tracks_m[side][track]->readSectorData(sector, pos, data);
+    return false;
 }
 
 void

--- a/VirtualH89/Src/TD0FloppyDisk.cpp
+++ b/VirtualH89/Src/TD0FloppyDisk.cpp
@@ -388,6 +388,7 @@ TD0FloppyDisk::findSector(int side,
                           int sector)
 {
 
+    debugss(ssFloppyDisk, INFO, "findSector - side: %d track %d sector: %d\n", side, track, sector);
     if (hypoTrack_m)
     {
         if ((track & 1) != 0)
@@ -401,6 +402,8 @@ TD0FloppyDisk::findSector(int side,
     {
         track *= 2;
     }
+    debugss(ssFloppyDisk, INFO, "findSector2 - side: %d track %d sector: %d\n", side, track,
+            sector);
 
     if (!tracks_m[side][track])
     {
@@ -445,6 +448,8 @@ TD0FloppyDisk::findSector(int side,
             curSector_m = nullptr;
             return false;
     }
+
+    debugss(ssFloppyDisk, INFO, "findSector - found\n");
 
     return true;
 }

--- a/VirtualH89/Src/Track.cpp
+++ b/VirtualH89/Src/Track.cpp
@@ -17,13 +17,22 @@ Track::Track(BYTE sideNum,
              BYTE trackNum): sideNum_m(sideNum),
                              trackNum_m(trackNum),
                              density_m(density_Unknown),
-                             dataRate_m(dr_Unknown)
+                             dataRate_m(dr_Unknown),
+                             formattingMode_m(fs_none)
 {
 
 }
 
 Track::~Track()
 {
+}
+
+void
+Track::startFormat()
+{
+    sectors_m.clear();
+    formattingMode_m = fs_waitingForIndex;
+
 }
 
 bool
@@ -59,12 +68,12 @@ Track::setDataRate(DataRate datarate)
 {
     dataRate_m = datarate;
 }
-
-bool
-Track::readSectorData(BYTE  sectorNum,
+/*
+   bool
+   Track::readSectorData(BYTE  sectorNum,
                       WORD  pos,
                       BYTE& data)
-{
+   {
     debugss(ssFloppyDisk, INFO, "sector: %d pos: %d\n", sectorNum, pos);
 
     shared_ptr<Sector> sector = findSector(sectorNum);
@@ -76,9 +85,8 @@ Track::readSectorData(BYTE  sectorNum,
     debugss(ssFloppyDisk, INFO, "Not found\n");
 
     return false;
-
-}
-
+   }
+ */
 shared_ptr<Sector>
 Track::findSector(BYTE sectorNum)
 {
@@ -98,7 +106,6 @@ Track::findSector(BYTE sectorNum)
 BYTE
 Track::getMaxSectors()
 {
-
     BYTE max = 0;
 
     for (shared_ptr<Sector> sector : sectors_m)

--- a/VirtualH89/Src/Track.h
+++ b/VirtualH89/Src/Track.h
@@ -47,6 +47,18 @@ class Track
     Density                                density_m;
     DataRate                               dataRate_m;
 
+    enum FormattingState
+    {
+        fs_none,
+        fs_waitingForIndex,
+        fs_writingGap,
+        fs_writingIdRecord,
+        fs_writingUserData
+    };
+
+    FormattingState formattingMode_m;
+
+
   public:
     Track(BYTE sideNum,
           BYTE trackNum);
@@ -61,10 +73,12 @@ class Track
 
     std::shared_ptr<Sector> findSector(BYTE sector);
 
-    bool readSectorData(BYTE  sector,
-                        WORD  pos,
-                        BYTE& data);
+    // bool readSectorData(BYTE  sector,
+    //                    WORD  pos,
+    //                    BYTE& data);
     BYTE getMaxSectors();
+
+    void startFormat();
 
 };
 

--- a/VirtualH89/Src/WD179xUserIf.h
+++ b/VirtualH89/Src/WD179xUserIf.h
@@ -21,7 +21,6 @@ class WD179xUserIf
     virtual void lowerIntrq()                     = 0;
     virtual void lowerDrq()                       = 0;
     virtual void loadHead(bool load);
-    virtual bool doubleDensity()                  = 0;
     virtual GenericFloppyDrive* getCurrentDrive() = 0;
     virtual int getClockPeriod()                  = 0;
     virtual bool readReady()                      = 0;

--- a/VirtualH89/Src/h19.cpp
+++ b/VirtualH89/Src/h19.cpp
@@ -843,7 +843,7 @@ H19::displayCharacter(unsigned int ch)
     screen_m[posX_m][posY_m] = symbol;
     posX_m++;
 
-    updated_m = true;
+    updated_m                = true;
 }
 
 /// \brief Process Carriage Return
@@ -1211,7 +1211,7 @@ H19::deleteChar()
     // clear the last column
     screen_m[cols_c - 1][posY_m] = ascii::SP;
 
-    updated_m = true;
+    updated_m                    = true;
 }
 
 void

--- a/VirtualH89/Src/h37.h
+++ b/VirtualH89/Src/h37.h
@@ -79,7 +79,6 @@ class Z_89_37: public DiskController, WD179xUserIf
     virtual void raiseDrq();
     virtual void lowerIntrq();
     virtual void lowerDrq();
-    virtual bool doubleDensity();
     virtual bool readReady();
     // virtual void loadHead(bool load);
     virtual int getClockPeriod();
@@ -88,7 +87,7 @@ class Z_89_37: public DiskController, WD179xUserIf
     void motorOn(bool motor);
 
     Computer*            computer_m;
-    WD1797*              wd1797;
+    WD1797*              wd1797_m;
     InterruptController* ic_m;
 
     static const BYTE    H37_NumPorts_c = 4;
@@ -144,7 +143,6 @@ class Z_89_37: public DiskController, WD179xUserIf
 
     bool                sectorTrackAccess_m;
 
-    Encoding            dataEncoding_m;
     DiskDrive*          drives_m[numDisks_c];
     GenericFloppyDrive* genericDrives_m[numDisks_c];
     Disks               curDiskDrive_m;

--- a/VirtualH89/Src/logger.cpp
+++ b/VirtualH89/Src/logger.cpp
@@ -8,6 +8,7 @@
 #include "WallClock.h"
 
 #define ANSI 0
+#define PRINT_CLOCK 1
 
 unsigned     debugLevel[ssMax];
 extern FILE* log_out;
@@ -40,7 +41,7 @@ setDebugLevel()
     debugLevel[ssAddressBus]             = defaultLevel; // Address Bus
     debugLevel[ssIO]                     = defaultLevel; // I/O ports
     debugLevel[ssH17]                    = defaultLevel; // H17 controller
-    debugLevel[ssH37]                    = INFO;         // H37 controller
+    debugLevel[ssH37]                    = defaultLevel; // H37 controller
     debugLevel[ssH47]                    = defaultLevel; // H47 controller
     debugLevel[ssH67]                    = defaultLevel; // H67 controller
     debugLevel[ssDiskDrive]              = defaultLevel; // Floppy disks
@@ -52,7 +53,7 @@ setDebugLevel()
     debugLevel[ss8250]                   = defaultLevel; // 8250 Serial Port
     debugLevel[ssTimer]                  = defaultLevel; // 2 mSec Timer
     debugLevel[ssWallClock]              = defaultLevel; // Wall Clock.
-    debugLevel[ssFloppyDisk]             = INFO;         // Floppy Disk
+    debugLevel[ssFloppyDisk]             = defaultLevel; // Floppy Disk
     debugLevel[ssGpp]                    = defaultLevel; // General Purpose Port
     debugLevel[ssParallel]               = defaultLevel; // Parallel Port Interface (Z47)
     debugLevel[ssStdioConsole]           = defaultLevel;
@@ -104,7 +105,9 @@ __debugss(enum logLevel level, const char* functionName, const char* fmt, ...)
     fprintf(log_out, "\x1b[37m");
 #endif
 
+#if PRINT_CLOCK
     WallClock::instance()->printTime(log_out);
+#endif
 
 #if ANSI
     fprintf(log_out, "\x1b[36m%s: \x1b[%dm", functionName, __val);

--- a/VirtualH89/Src/mms77316.h
+++ b/VirtualH89/Src/mms77316.h
@@ -10,13 +10,14 @@
 #define MMS77316_H_
 
 
-#include "wd1797.h"
+#include "WD179xUserIf.h"
 #include "DiskController.h"
 #include "propertyutil.h"
 
 class GenericFloppyDrive;
 class GenericDiskDrive;
 class InterruptController;
+class WD1797;
 
 ///
 /// \brief Virtual soft-sectored disk controller
@@ -25,7 +26,7 @@ class InterruptController;
 ///
 /// The MMS77316 uses the 1797-02 controller.
 ///
-class MMS77316: public DiskController, WD1797
+class MMS77316: public DiskController, WD179xUserIf
 {
   public:
     static const int numDisks_c = 8;
@@ -64,19 +65,20 @@ class MMS77316: public DiskController, WD1797
     static const char* MMS77316_Name_c;
 
   private:
+    bool               intrqRaised_m;
+    bool               drqRaised_m;
     void raiseIntrq();
     void raiseDrq();
     void lowerIntrq();
     void lowerDrq();
 
-    static const BYTE MMS77316_NumPorts_c  = 8;
+    static const BYTE    MMS77316_NumPorts_c  = 8;
 
-    static const BYTE BasePort_c           = 0x38;
-    static const BYTE ControlPort_Offset_c = 0;
-    static const BYTE Wd1797_Offset_c      = 4;
-    BYTE              controlReg_m;
+    static const BYTE    BasePort_c           = 0x38;
+    static const BYTE    ControlPort_Offset_c = 0;
+    static const BYTE    Wd1797_Offset_c      = 4;
+    BYTE                 controlReg_m;
 
-    GenericFloppyDrive* getCurDrive();
     int getClockPeriod();
 
     InterruptController* ic_m;
@@ -105,12 +107,12 @@ class MMS77316: public DiskController, WD1797
         return (controlReg_m & ctrl_EnableIntReq_c) != 0 &&
                ((controlReg_m & ctrl_EnableBurstN_c) != 0 || drqCount_m < 1);
     }
-    // These are virtual in wd1797 so it can use it.
-    bool doubleDensity()
-    {
-        return (controlReg_m & ctrl_SetMFMRecordingN_c) == 0;
-    }
     void loadHead(bool load);
+
+    virtual GenericFloppyDrive* getCurrentDrive();
+    virtual bool readReady();
+
+    WD1797* wd1797_m;
 };
 
 #endif // MMS77316_H_

--- a/VirtualH89/Src/z80.cpp
+++ b/VirtualH89/Src/z80.cpp
@@ -1803,7 +1803,7 @@ Z80::execute(WORD numInst)
             PC        = 0x66;
             mode      = cm_running;
             R++; // increment refresh register
-            ticks -= 11;
+            ticks    -= 11;
         }
         else if ((int_type & Intr_INT) && (IFF1))
         {
@@ -1816,7 +1816,7 @@ Z80::execute(WORD numInst)
             {
                 case 0:
                     debugss(ssZ80, VERBOSE, "Processing interrupt mode 0\n");
-                    ticks -= 2;
+                    ticks         -= 2;
                     processingIntr = true;
                     break;
 


### PR DESCRIPTION
- properly handling 48tpi/96tpi drive
- fix a strange R/O issue with CP/M 2.2.03 distribution disk
- H89 software properly detecting the number of drives attached to the controller
  This also restructured the wd1797 handling of commands, to make it more
  modular. For example, each class of commands now has it's own notification method.

Still TODO: implement full track read/write on the WD1797.
